### PR TITLE
Add hub URL configuration to Beszel agent service role

### DIFF
--- a/roles/agent/defaults/main.yml
+++ b/roles/agent/defaults/main.yml
@@ -25,3 +25,5 @@ agent_service_enabled: true
 agent_service_state: started
 # Extra filesystems to be monitored by the Beszel binary agent
 agent_extra_filesystems: []
+# URL of the Beszel hub for the Beszel binary agent to connect to
+agent_hub_url: ""

--- a/roles/agent/templates/beszel-agent.service.j2
+++ b/roles/agent/templates/beszel-agent.service.j2
@@ -8,6 +8,9 @@ User={{ agent_user }}
 ExecStart={{ agent_install_dir }}/beszel-agent {{ agent_args | trim }}
 Environment="PORT={{ agent_port }}"
 Environment="KEY={{ agent_public_key }}"
+{% if agent_hub_url %}
+Environment="HUB_URL={{ agent_hub_url }}"
+{% endif %}
 {% if agent_extra_filesystems %}
 Environment="EXTRA_FILESYSTEMS={{ agent_extra_filesystems | join(',') }}"
 {% endif %}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When installing the agent manually in the hub, the provided command includes the `-url` argument set to the current Hub URL. This ultimately gets added to the `systemd` file as an environment variable `HUB_URL`. 

With this change, there is a new `agent_hub_url` which, if not empty, will be added to the service file:

```
{% if agent_hub_url %}
Environment="HUB_URL={{ agent_hub_url }}"
{% endif %}
```

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

