### PR TITLE
feat(agent): Add support for local binary deployment for offline environments

### DIFF
--- a/roles/agent/README.md
+++ b/roles/agent/README.md
@@ -23,6 +23,17 @@ agent_version: latest
 Version of the Beszel binary agent to install. Can be a specific version from GitHub (e.g., `v0.9.1`).
 
 ```yaml
+agent_local_binary: ""
+```
+
+Local path to Beszel binary agent package (optional). When set, will use this local file instead of downloading from GitHub. This should point to the `beszel-agent` binary or tarball on the Ansible controller. This is useful for offline deployments or when target hosts have no internet connectivity.
+
+Example:
+```yaml
+agent_local_binary: "/path/to/beszel-agent"
+```
+
+```yaml
 agent_port: 45876
 ```
 
@@ -99,6 +110,18 @@ This role depends on precompiled binaries published on GitHub at [henrygd/beszel
     - role: community.beszel.agent
       vars:
         agent_public_key: "<Public key for Beszel hub>"
+```
+
+### Example with Local Binary (Offline Deployment)
+
+```yaml
+- name: Install and configure a Beszel binary agent using local binary.
+  hosts: all
+  roles:
+    - role: community.beszel.agent
+      vars:
+        agent_public_key: "<Public key for Beszel hub>"
+        agent_local_binary: "/path/to/local/beszel-agent"
 ```
 
 ## Contributors

--- a/roles/agent/defaults/main.yml
+++ b/roles/agent/defaults/main.yml
@@ -9,6 +9,10 @@ agent_state: present
 # Version of the Beszel binary agent to install
 # Can be a specific version from GitHub (e.g., v0.9.1)
 agent_version: latest
+# Local path to Beszel binary agent package (optional)
+# When set, will use this local file instead of downloading from GitHub
+# Should point to the beszel-agent binary or tarball on the Ansible controller
+agent_local_binary: ""
 # Port for the Beszel binary agent to listen on
 agent_port: 45876
 # Public key used to authenticate the Beszel binary agent to the Hub

--- a/roles/agent/tasks/agent_present.yml
+++ b/roles/agent/tasks/agent_present.yml
@@ -21,6 +21,14 @@
         arm
       {% endif %}
 
+- name: agent_present | Copy local Beszel binary agent
+  ansible.builtin.copy:
+    src: "{{ agent_local_binary }}"
+    dest: "{{ agent_install_dir }}/beszel-agent"
+    mode: u=rwx,g=rx,o=rx
+  notify: Restart Beszel binary agent systemd service
+  when: agent_local_binary != ""
+
 - name: agent_present | Download Beszel binary agent tarball
   ansible.builtin.get_url:
     url: |
@@ -32,6 +40,7 @@
     dest: /tmp/beszel-agent.tar.gz
     force: true
     mode: u=rw,g=,o=
+  when: agent_local_binary == ""
 
 - name: agent_present | Extract Beszel binary agent tarball
   notify: Restart Beszel binary agent systemd service
@@ -40,6 +49,7 @@
     dest: "{{ agent_install_dir }}"
     mode: u=rwx,g=rx,o=rx
     remote_src: true
+  when: agent_local_binary == ""
 
 - name: agent_present | Create user for the Beszel binary agent
   ansible.builtin.user:


### PR DESCRIPTION
##### SUMMARY
Adds support for using a local Beszel binary agent package instead of downloading from GitHub, enabling offline and disconnected deployments where target nodes have no internet connectivity. Resolves #13.

This change introduces a new optional variable `agent_local_binary` that allows users to specify the path to a local binary on the Ansible controller. When this variable is set, the role will copy the local binary to the target host instead of downloading it from GitHub releases. The implementation maintains full backward compatibility - when `agent_local_binary` is not set or empty, the role behaves exactly as before.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
community.beszel.agent

##### ADDITIONAL INFORMATION
**Changes Made:**
1. Added `agent_local_binary` variable in `defaults/main.yml` with default empty value
2. Modified `tasks/agent_present.yml` to conditionally use local binary or download from GitHub
3. Updated `README.md` with documentation and usage examples for the new feature

**Usage Example:**
```yaml
- name: Install Beszel agent using local binary
  hosts: all
  roles:
    - role: community.beszel.agent
      vars:
        agent_public_key: "your-public-key"
        agent_local_binary: "/path/to/local/beszel-agent"