### PR TITLE
Add role variable to specify uid of the agent user

### DIFF
--- a/roles/agent/README.md
+++ b/roles/agent/README.md
@@ -64,6 +64,12 @@ agent_user: beszel
 Name of the user to create and run the Beszel binary agent as.
 
 ```yaml
+agent_uid: 1001
+```
+
+UID for the agent user. (Chosen automatically by the OS if not specified)
+
+```yaml
 agent_args: ""
 ```
 

--- a/roles/agent/tasks/agent_present.yml
+++ b/roles/agent/tasks/agent_present.yml
@@ -66,6 +66,7 @@
 - name: agent_present | Create user for the Beszel binary agent
   ansible.builtin.user:
     name: "{{ agent_user }}"
+    uid: "{{ agent_uid | default(omit) }}"
     shell: /sbin/nologin
     system: true
     create_home: false


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add role variable to specify uid of the agent user. Fixes #26 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
roles/agent

##### ADDITIONAL INFORMATION
Adds an optional `uid` parameter to the `ansible.builtin.user` call. There is no `gid` parameter, but I think it ends up being the same as `uid` if specified, though this may be OS-dependent.
