### PR TITLE
OpenRC support for agent and hub

### DIFF
--- a/changelogs/fragments/openrc-support.yml
+++ b/changelogs/fragments/openrc-support.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - community.beszel.agent - Add OpenRC service manager support.
+  - community.beszel.hub - Add OpenRC service manager support.

--- a/extensions/molecule/agent_openrc/converge.yml
+++ b/extensions/molecule/agent_openrc/converge.yml
@@ -1,0 +1,30 @@
+---
+- name: Converge
+  hosts: molecule
+  gather_facts: true
+  pre_tasks:
+    # OpenRC is installed in prepare. Ensure it is running so the role detects
+    # service_mgr == 'openrc' (the role assumes an OpenRC system, it does not install it).
+    - name: Converge | Start OpenRC
+      ansible.builtin.command: openrc boot
+      changed_when: false
+
+    - name: Converge | Verify service manager detection
+      ansible.builtin.assert:
+        that:
+          - ansible_service_mgr == 'openrc'
+        fail_msg: "Expected ansible_service_mgr to be 'openrc', but got '{{ ansible_service_mgr }}'"
+
+  roles:
+    - role: community.beszel.agent
+
+  post_tasks:
+    - name: Converge | Add Beszel binary agent to Beszel Hub
+      delegate_to: localhost
+      community.beszel.system:
+        url: http://localhost:8090
+        username: molecule@example.com
+        password: molecule
+        name: instance
+        host: instance
+        state: present

--- a/extensions/molecule/agent_openrc/create.yml
+++ b/extensions/molecule/agent_openrc/create.yml
@@ -1,0 +1,65 @@
+---
+- name: Create | Common Create Tasks
+  ansible.builtin.import_playbook: ../common/create.yml
+
+- name: Create | Get Beszel Public Key
+  ansible.builtin.import_playbook: ../common/beszel_public_key.yml
+
+- name: Create | Get Beszel Universal Token (agent_openrc)
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Create | Get Beszel Hub PocketBase API token with superusers authentication method
+      register: beszel_hub_api_token_resp
+      ansible.builtin.uri:
+        url: http://localhost:8090/api/collections/_superusers/auth-with-password
+        method: POST
+        headers:
+          Authorization: ""
+        body:
+          identity: molecule@example.com
+          password: molecule
+        body_format: json
+
+    - name: Create | Enable Beszel Universal Token
+      register: beszel_universal_token_resp
+      ansible.builtin.uri:
+        url: http://localhost:8090/api/beszel/universal-token?enable=1
+        method: GET
+        headers:
+          Authorization: "{{ beszel_hub_api_token_resp.json.token }}"
+
+- name: Create | agent_openrc
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Create | Add container to molecule_inventory
+      vars:
+        inventory_partial_yaml: |
+          all:
+            children:
+              molecule:
+                vars:
+                  agent_public_key: "{{ beszel_hub_public_key_resp.json.key }}"
+                  agent_token: "{{ beszel_universal_token_resp.json.token }}"
+                  agent_hub_url: http://beszel:8090
+                  agent_name: molecule
+                hosts:
+                  "{{ item.name }}":
+                    ansible_connection: community.docker.docker
+      ansible.builtin.set_fact:
+        molecule_inventory: >
+          {{ molecule_inventory | combine(inventory_partial_yaml | from_yaml, recursive=true) }}
+      loop: "{{ molecule_yml.platforms }}"
+      loop_control:
+        label: "{{ item.name }}"
+
+    - name: Create | Dump molecule_inventory
+      ansible.builtin.copy:
+        content: |
+          {{ molecule_inventory | to_yaml }}
+        dest: "{{ molecule_ephemeral_directory }}/inventory/molecule_inventory.yml"
+        mode: "0600"
+
+    - name: Create | Force inventory refresh
+      ansible.builtin.meta: refresh_inventory

--- a/extensions/molecule/agent_openrc/destroy.yml
+++ b/extensions/molecule/agent_openrc/destroy.yml
@@ -1,0 +1,5 @@
+---
+# Skip uninstall on instance (Alpine may not have Python if prepare/converge never ran).
+# Container removal in common destroy is sufficient.
+- name: Destroy | Common Tasks
+  ansible.builtin.import_playbook: ../common/destroy.yml

--- a/extensions/molecule/agent_openrc/molecule.yml
+++ b/extensions/molecule/agent_openrc/molecule.yml
@@ -1,0 +1,33 @@
+---
+driver:
+  name: docker
+dependency:
+  name: galaxy
+  options:
+    requirements-file: "${MOLECULE_SCENARIO_DIRECTORY}/../requirements.yml"
+provisioner:
+  name: ansible
+  playbooks:
+    prepare: prepare.yml
+  env:
+    # Use collection from repo root (must run 'ansible-galaxy collection install . --force' from repo root once)
+    ANSIBLE_COLLECTIONS_PATH: "${MOLECULE_SCENARIO_DIRECTORY}/../../.."
+platforms:
+  - name: instance
+    image: docker.io/alpine:latest
+    command: /sbin/init
+    tmpfs:
+      - /run
+      - /tmp
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    cgroupns_mode: host
+    privileged: true
+    expose:
+      - 45876
+    networks:
+      - name: molecule_beszel
+    env:
+      ANSIBLE_PYTHON_INTERPRETER: auto_silent
+scenario:
+  name: agent_openrc

--- a/extensions/molecule/agent_openrc/prepare.yml
+++ b/extensions/molecule/agent_openrc/prepare.yml
@@ -1,0 +1,12 @@
+---
+- name: Prepare
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Prepare | Install Python and required packages in container
+      community.docker.docker_container_exec:
+        container: instance
+        command: sh -c "apk update && apk add --no-cache python3 py3-pip openrc tar && ln -sf /usr/bin/python3 /usr/bin/python || true"
+      register: prepare_output
+      changed_when: prepare_output.rc == 0
+      failed_when: prepare_output.rc != 0

--- a/extensions/molecule/agent_openrc/verify.yml
+++ b/extensions/molecule/agent_openrc/verify.yml
@@ -1,0 +1,67 @@
+---
+- name: Verify
+  hosts: molecule
+  tasks:
+    - name: Verify | Check ansible_service_mgr is openrc
+      ansible.builtin.assert:
+        that:
+          - ansible_service_mgr == 'openrc'
+        fail_msg: "Service manager should be 'openrc' but is '{{ ansible_service_mgr }}'"
+
+    - name: Verify | Check OpenRC init script exists
+      ansible.builtin.stat:
+        path: /etc/init.d/beszel-agent
+      register: openrc_script
+
+    - name: Verify | Assert OpenRC init script exists
+      ansible.builtin.assert:
+        that:
+          - openrc_script.stat.exists
+          - openrc_script.stat.isreg
+        fail_msg: "OpenRC init script /etc/init.d/beszel-agent does not exist"
+
+    - name: Verify | Check OpenRC init script is executable
+      ansible.builtin.assert:
+        that:
+          - openrc_script.stat.mode | int >= 0o755
+        fail_msg: "OpenRC init script is not executable"
+
+    - name: Verify | Check service is in default runlevel
+      ansible.builtin.stat:
+        path: /etc/runlevels/default/beszel-agent
+      register: runlevel_link
+
+    - name: Verify | Assert service is in default runlevel
+      ansible.builtin.assert:
+        that:
+          - runlevel_link.stat.exists
+        fail_msg: "Service beszel-agent is not in default runlevel"
+
+    - name: Verify | Check beszel-agent service is running
+      ansible.builtin.command: rc-status -a
+      register: rc_status
+      changed_when: false
+      retries: 24
+      delay: 5
+      until: >
+        'beszel-agent' in rc_status.stdout and
+        ('started' in rc_status.stdout or 'run' in rc_status.stdout)
+
+    - name: Verify | Assert beszel-agent service is started
+      ansible.builtin.assert:
+        that:
+          - "'beszel-agent' in rc_status.stdout"
+          - "'started' in rc_status.stdout or 'run' in rc_status.stdout"
+        fail_msg: "beszel-agent service is not running according to rc-status"
+
+    - name: Verify | Check beszel-agent process is running
+      ansible.builtin.command: pgrep -f beszel-agent
+      register: beszel_process
+      changed_when: false
+      failed_when: false
+
+    - name: Verify | Assert beszel-agent process exists
+      ansible.builtin.assert:
+        that:
+          - beszel_process.rc == 0
+        fail_msg: "beszel-agent process is not running"

--- a/extensions/molecule/hub_openrc/converge.yml
+++ b/extensions/molecule/hub_openrc/converge.yml
@@ -1,0 +1,17 @@
+---
+- name: Converge
+  hosts: molecule
+  gather_facts: true
+  pre_tasks:
+    - name: Converge | Start OpenRC
+      ansible.builtin.command: openrc boot
+      changed_when: false
+
+    - name: Converge | Verify service manager detection
+      ansible.builtin.assert:
+        that:
+          - ansible_service_mgr == 'openrc'
+        fail_msg: "Expected ansible_service_mgr to be 'openrc', but got '{{ ansible_service_mgr }}'"
+
+  roles:
+    - role: community.beszel.hub

--- a/extensions/molecule/hub_openrc/create.yml
+++ b/extensions/molecule/hub_openrc/create.yml
@@ -1,0 +1,64 @@
+---
+- name: Create
+  hosts: localhost
+  gather_facts: false
+  vars:
+    molecule_inventory:
+      all:
+        hosts: {}
+        children:
+          molecule: {}
+  tasks:
+    - name: Create | Create container
+      community.docker.docker_container:
+        name: "{{ item.name }}"
+        image: "{{ item.image }}"
+        command: "{{ item.command }}"
+        tmpfs: "{{ item.tmpfs }}"
+        volumes: "{{ item.volumes }}"
+        cgroupns_mode: "{{ item.cgroupns_mode }}"
+        privileged: "{{ item.privileged }}"
+        state: started
+      register: result
+      loop: "{{ molecule_yml.platforms }}"
+
+    - name: Create | Fail if container is not running
+      when: >
+        item.container.State.ExitCode != 0 or
+        not item.container.State.Running
+      ansible.builtin.fail:
+        msg: "{{ item.container.Name }} failed to start."
+      loop: "{{ result.results }}"
+
+    - name: Create | Add container to molecule_inventory
+      vars:
+        inventory_partial_yaml: |
+          all:
+            children:
+              molecule:
+                hosts:
+                  "{{ item.name }}":
+                    ansible_connection: community.docker.docker
+      ansible.builtin.set_fact:
+        molecule_inventory: >
+          {{ molecule_inventory | combine(inventory_partial_yaml | from_yaml, recursive=true) }}
+      loop: "{{ molecule_yml.platforms }}"
+      loop_control:
+        label: "{{ item.name }}"
+
+    - name: Create | Dump molecule_inventory
+      ansible.builtin.copy:
+        content: |
+          {{ molecule_inventory | to_yaml }}
+        dest: "{{ molecule_ephemeral_directory }}/inventory/molecule_inventory.yml"
+        mode: "0600"
+
+    - name: Create | Force inventory refresh
+      ansible.builtin.meta: refresh_inventory
+
+    - name: Create | Fail if molecule group is missing
+      run_once: true # noqa: run-once[task]
+      ansible.builtin.assert:
+        that: "'molecule' in groups"
+        fail_msg: |
+          molecule group was not found inside inventory groups: {{ groups }}

--- a/extensions/molecule/hub_openrc/destroy.yml
+++ b/extensions/molecule/hub_openrc/destroy.yml
@@ -1,0 +1,22 @@
+---
+- name: Destroy | Uninstall Beszel hub
+  hosts: molecule
+  roles:
+    - role: community.beszel.hub
+      vars:
+        hub_state: absent
+
+- name: Destroy | Cleanup
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Destroy | Stop and remove container
+      community.docker.docker_container:
+        name: instance
+        state: absent
+        auto_remove: true
+
+    - name: Destroy | Remove dynamic inventory file
+      ansible.builtin.file:
+        path: "{{ molecule_ephemeral_directory }}/inventory/molecule_inventory.yml"
+        state: absent

--- a/extensions/molecule/hub_openrc/molecule.yml
+++ b/extensions/molecule/hub_openrc/molecule.yml
@@ -1,0 +1,28 @@
+---
+driver:
+  name: docker
+dependency:
+  name: galaxy
+  options:
+    requirements-file: "${MOLECULE_SCENARIO_DIRECTORY}/../requirements.yml"
+provisioner:
+  name: ansible
+  playbooks:
+    prepare: prepare.yml
+  env:
+    ANSIBLE_COLLECTIONS_PATH: "${MOLECULE_SCENARIO_DIRECTORY}/../../.."
+platforms:
+  - name: instance
+    image: docker.io/alpine:latest
+    command: /sbin/init
+    tmpfs:
+      - /run
+      - /tmp
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    cgroupns_mode: host
+    privileged: true
+    env:
+      ANSIBLE_PYTHON_INTERPRETER: auto_silent
+scenario:
+  name: hub_openrc

--- a/extensions/molecule/hub_openrc/prepare.yml
+++ b/extensions/molecule/hub_openrc/prepare.yml
@@ -1,0 +1,12 @@
+---
+- name: Prepare
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Prepare | Install Python and required packages in container
+      community.docker.docker_container_exec:
+        container: instance
+        command: sh -c "apk update && apk add --no-cache python3 py3-pip openrc tar ca-certificates && ln -sf /usr/bin/python3 /usr/bin/python || true"
+      register: prepare_output
+      changed_when: prepare_output.rc == 0
+      failed_when: prepare_output.rc != 0

--- a/extensions/molecule/hub_openrc/verify.yml
+++ b/extensions/molecule/hub_openrc/verify.yml
@@ -1,0 +1,63 @@
+---
+- name: Verify
+  hosts: molecule
+  tasks:
+    - name: Verify | Check ansible_service_mgr is openrc
+      ansible.builtin.assert:
+        that:
+          - ansible_service_mgr == 'openrc'
+        fail_msg: "Service manager should be 'openrc' but is '{{ ansible_service_mgr }}'"
+
+    - name: Verify | Check OpenRC init script exists
+      ansible.builtin.stat:
+        path: /etc/init.d/beszel-hub
+      register: openrc_script
+
+    - name: Verify | Assert OpenRC init script exists
+      ansible.builtin.assert:
+        that:
+          - openrc_script.stat.exists
+          - openrc_script.stat.isreg
+        fail_msg: "OpenRC init script /etc/init.d/beszel-hub does not exist"
+
+    - name: Verify | Check OpenRC init script is executable
+      ansible.builtin.assert:
+        that:
+          - openrc_script.stat.mode | int >= 0o755
+        fail_msg: "OpenRC init script is not executable"
+
+    - name: Verify | Check service is in default runlevel
+      ansible.builtin.stat:
+        path: /etc/runlevels/default/beszel-hub
+      register: runlevel_link
+
+    - name: Verify | Assert service is in default runlevel
+      ansible.builtin.assert:
+        that:
+          - runlevel_link.stat.exists
+        fail_msg: "Service beszel-hub is not in default runlevel"
+
+    - name: Verify | Check beszel-hub service is running
+      ansible.builtin.command: rc-status -a
+      register: rc_status
+      changed_when: false
+      retries: 24
+      delay: 5
+      until: >
+        'beszel-hub' in rc_status.stdout and
+        ('started' in rc_status.stdout or 'run' in rc_status.stdout)
+
+    - name: Verify | Assert beszel-hub service is started
+      ansible.builtin.assert:
+        that:
+          - "'beszel-hub' in rc_status.stdout"
+          - "'started' in rc_status.stdout or 'run' in rc_status.stdout"
+        fail_msg: "beszel-hub service is not running according to rc-status"
+
+    - name: Verify | Check Beszel hub is healthy
+      ansible.builtin.uri:
+        url: http://localhost:8090/api/health
+        method: GET
+        status_code: 200
+      register: beszel_hub_health
+      changed_when: false

--- a/roles/agent/defaults/main.yml
+++ b/roles/agent/defaults/main.yml
@@ -20,6 +20,9 @@ agent_install_dir: /usr/local/bin
 agent_user: beszel
 # Custom arguments for the Beszel binary agent
 agent_args: ""
+# Service manager used to manage the Beszel binary agent service
+# When null, the role sets it from ansible_facts.service_mgr (e.g. systemd or openrc)
+agent_service_manager: null
 # Enable the Beszel binary agent systemd service on boot
 agent_service_enabled: true
 # State of the Beszel binary agent systemd service

--- a/roles/agent/handlers/main.yml
+++ b/roles/agent/handlers/main.yml
@@ -3,8 +3,30 @@
 - name: Reload systemd configuration
   ansible.builtin.systemd_service:
     daemon_reload: true
+  when: agent_service_manager == 'systemd'
 
 - name: Restart Beszel binary agent systemd service
   ansible.builtin.service:
     name: beszel-agent
     state: restarted
+  when: agent_service_manager == 'systemd'
+  listen: Restart Beszel binary agent service
+
+- name: Restart Beszel binary agent service (OpenRC) | Restart service
+  ansible.builtin.command: rc-service beszel-agent restart
+  when: agent_service_manager == 'openrc'
+  listen: Restart Beszel binary agent service
+  async: 120
+  poll: 0
+  changed_when: true
+
+- name: Restart Beszel binary agent service (OpenRC) | Wait for service to be running
+  ansible.builtin.command: rc-service beszel-agent status
+  register: agent_openrc_restart_status
+  until: agent_openrc_restart_status.rc == 0
+  retries: 12
+  delay: 5
+  failed_when: false
+  when: agent_service_manager == 'openrc'
+  listen: Restart Beszel binary agent service
+  changed_when: false

--- a/roles/agent/tasks/agent_absent.yml
+++ b/roles/agent/tasks/agent_absent.yml
@@ -1,14 +1,55 @@
 ---
 # absent tasks file for agent
+- name: agent_absent | Set service manager from detected facts when not explicitly set
+  ansible.builtin.set_fact:
+    agent_svc_mgr_candidate: "{{ agent_service_manager | default(ansible_facts.service_mgr) }}"
+
+- name: agent_absent | Set agent_service_manager from candidate
+  ansible.builtin.set_fact:
+    agent_service_manager: >-
+      {{ agent_svc_mgr_candidate if agent_svc_mgr_candidate in ['systemd', 'openrc']
+         else 'auto' }}
+
+- name: agent_absent | Detect service manager from system when facts are ambiguous
+  when: agent_service_manager == 'auto'
+  block:
+    - name: agent_absent | Check for systemd and OpenRC
+      ansible.builtin.stat:
+        path: "{{ item }}"
+      register: _agent_service_mgr_paths
+      loop:
+        - /etc/systemd/system
+        - /sbin/openrc
+        - /sbin/openrc-run
+
+    - name: agent_absent | Set has_systemd and has_openrc from filesystem
+      ansible.builtin.set_fact:
+        agent_has_systemd: "{{ _agent_service_mgr_paths.results[0].stat.isdir | default(false) }}"
+        agent_has_openrc: >-
+          {{ _agent_service_mgr_paths.results[1].stat.exists | default(false)
+             or _agent_service_mgr_paths.results[2].stat.exists | default(false) }}
+
+    - name: agent_absent | Set agent_service_manager from filesystem
+      ansible.builtin.set_fact:
+        agent_service_manager: >-
+          {{ 'systemd' if agent_has_systemd else ('openrc' if agent_has_openrc else 'systemd') }}
+
 - name: agent_absent | Stop Beszel binary agent systemd service
+  when: agent_service_manager == 'systemd'
   ansible.builtin.service:
     name: beszel-agent
     state: stopped
 
 - name: agent_absent | Remove Beszel binary agent systemd service
+  when: agent_service_manager == 'systemd'
   ansible.builtin.file:
     path: /etc/systemd/system/beszel-agent.service
     state: absent
+
+- name: agent_absent | Include OpenRC absent tasks
+  when: agent_service_manager == 'openrc'
+  ansible.builtin.include_tasks:
+    file: agent_absent_openrc.yml
 
 - name: agent_absent | Remove user for the Beszel binary agent
   ansible.builtin.user:

--- a/roles/agent/tasks/agent_absent_openrc.yml
+++ b/roles/agent/tasks/agent_absent_openrc.yml
@@ -1,0 +1,18 @@
+---
+# openrc absent tasks for agent
+- name: agent_absent | Stop Beszel binary agent service
+  ansible.builtin.command: rc-service beszel-agent stop
+  register: agent_openrc_stop_result
+  failed_when: agent_openrc_stop_result.rc not in [0, 1]
+  changed_when: true
+
+- name: agent_absent | Remove Beszel binary agent OpenRC service script
+  ansible.builtin.file:
+    path: /etc/init.d/beszel-agent
+    state: absent
+
+- name: agent_absent | Remove Beszel binary agent from default runlevel
+  ansible.builtin.command: rc-update del beszel-agent default
+  register: agent_rc_update_del_result
+  failed_when: agent_rc_update_del_result.rc not in [0, 1]
+  changed_when: true

--- a/roles/agent/tasks/agent_present.yml
+++ b/roles/agent/tasks/agent_present.yml
@@ -1,5 +1,39 @@
 ---
 # present tasks file for agent
+- name: agent_present | Set service manager from detected facts when not explicitly set
+  ansible.builtin.set_fact:
+    agent_svc_mgr_candidate: "{{ agent_service_manager | default(ansible_facts.service_mgr) }}"
+
+- name: agent_present | Set agent_service_manager from candidate
+  ansible.builtin.set_fact:
+    agent_service_manager: >-
+      {{ agent_svc_mgr_candidate if agent_svc_mgr_candidate in ['systemd', 'openrc']
+         else 'auto' }}
+
+- name: agent_present | Detect service manager from system when facts are ambiguous
+  when: agent_service_manager == 'auto'
+  block:
+    - name: agent_present | Check for systemd and OpenRC
+      ansible.builtin.stat:
+        path: "{{ item }}"
+      register: _agent_service_mgr_paths
+      loop:
+        - /etc/systemd/system
+        - /sbin/openrc
+        - /sbin/openrc-run
+
+    - name: agent_present | Set has_systemd and has_openrc from filesystem
+      ansible.builtin.set_fact:
+        agent_has_systemd: "{{ _agent_service_mgr_paths.results[0].stat.isdir | default(false) }}"
+        agent_has_openrc: >-
+          {{ _agent_service_mgr_paths.results[1].stat.exists | default(false)
+             or _agent_service_mgr_paths.results[2].stat.exists | default(false) }}
+
+    - name: agent_present | Set agent_service_manager from filesystem
+      ansible.builtin.set_fact:
+        agent_service_manager: >-
+          {{ 'systemd' if agent_has_systemd else ('openrc' if agent_has_openrc else 'systemd') }}
+
 - name: agent_present | Assert valid authentication method is provided
   ansible.builtin.assert:
     that:
@@ -14,6 +48,14 @@
 
 - name: agent_present | Gather package facts
   ansible.builtin.package_facts:
+
+- name: agent_present | Ensure GNU tar is available for tarball extraction
+  when:
+    - not agent_airgap
+    - ansible_os_family == 'Alpine' or ansible_distribution == 'Alpine'
+  ansible.builtin.package:
+    name: tar
+    state: present
 
 - name: agent_present | Download and install Beszel binary agent from GitHub
   when: not agent_airgap
@@ -46,19 +88,30 @@
         mode: u=rw,g=,o=
 
     - name: agent_present | Extract Beszel binary agent tarball
-      when: not ansible_check_mode
-      notify: Restart Beszel binary agent systemd service
+      notify: Restart Beszel binary agent service
       ansible.builtin.unarchive:
         src: /tmp/beszel-agent.tar.gz
         dest: "{{ agent_install_dir }}"
         mode: u=rwx,g=rx,o=rx
         remote_src: true
+      when: ansible_os_family != 'Alpine' and ansible_distribution != 'Alpine' and not ansible_check_mode
+
+    - name: agent_present | Extract Beszel binary agent tarball (Alpine with GNU tar in PATH)
+      notify: Restart Beszel binary agent service
+      ansible.builtin.unarchive:
+        src: /tmp/beszel-agent.tar.gz
+        dest: "{{ agent_install_dir }}"
+        mode: u=rwx,g=rx,o=rx
+        remote_src: true
+      environment:
+        PATH: "/usr/bin:{{ ansible_env.PATH | default('') }}"
+      when: (ansible_os_family == 'Alpine' or ansible_distribution == 'Alpine') and not ansible_check_mode
 
 - name: agent_present | Install Beszel binary agent in air-gapped mode
   when: agent_airgap
   block:
     - name: agent_present | Copy Beszel binary agent from Ansible Controller
-      notify: Restart Beszel binary agent systemd service
+      notify: Restart Beszel binary agent service
       ansible.builtin.copy:
         src: beszel-agent
         dest: "{{ agent_install_dir }}/beszel-agent"
@@ -75,7 +128,13 @@
     append: true
     state: present
 
+- name: agent_present | Fail on unsupported service manager for Beszel binary agent
+  ansible.builtin.fail:
+    msg: "Service manager {{ agent_service_manager }} is not supported for the Beszel binary agent. Supported values are 'systemd' and 'openrc'."
+  when: agent_service_manager not in ['systemd', 'openrc']
+
 - name: agent_present | Install Beszel binary agent systemd service
+  when: agent_service_manager == 'systemd'
   notify:
     - Reload systemd configuration
     - Restart Beszel binary agent systemd service
@@ -84,10 +143,16 @@
     dest: /etc/systemd/system/beszel-agent.service
     mode: u=rw,g=r,o=r
 
+- name: agent_present | Include OpenRC service tasks
+  when: agent_service_manager == 'openrc'
+  ansible.builtin.include_tasks:
+    file: agent_present_openrc.yml
+
 - name: agent_present | Flush handlers
   ansible.builtin.meta: flush_handlers
 
 - name: agent_present | Start the Beszel binary agent systemd service
+  when: agent_service_manager == 'systemd'
   ansible.builtin.service:
     name: beszel-agent
     enabled: "{{ agent_service_enabled }}"

--- a/roles/agent/tasks/agent_present_openrc.yml
+++ b/roles/agent/tasks/agent_present_openrc.yml
@@ -1,0 +1,35 @@
+---
+# openrc present tasks for agent
+- name: agent_present | Install Beszel binary agent OpenRC service script
+  ansible.builtin.template:
+    src: beszel-agent.openrc.j2
+    dest: /etc/init.d/beszel-agent
+    mode: u=rwx,g=rx,o=rx
+
+- name: agent_present | Ensure Beszel binary agent added to default runlevel
+  ansible.builtin.command: rc-update add beszel-agent default
+  args:
+    creates: /etc/runlevels/default/beszel-agent
+
+- name: agent_present | Flush handlers
+  ansible.builtin.meta: flush_handlers
+
+- name: agent_present | Get OpenRC service status
+  ansible.builtin.command: rc-service beszel-agent status
+  register: agent_openrc_status
+  changed_when: false
+  failed_when: false
+  retries: 12
+  delay: 3
+  until: agent_openrc_status.rc != 8
+
+- name: agent_present | Start the Beszel binary agent service
+  ansible.builtin.command: "rc-service beszel-agent {{ 'stop' if agent_service_state == 'stopped' else 'start' }}"
+  when:
+    - (agent_service_state == 'started' and agent_openrc_status.rc not in [0, 8]) or (agent_service_state == 'stopped' and agent_openrc_status.rc == 0)
+  register: agent_openrc_start
+  changed_when: false
+  failed_when: >
+    agent_openrc_start.rc != 0
+    and 'stopped by something else' not in (agent_openrc_start.stderr | default(''))
+    and 'already starting' not in (agent_openrc_start.stderr | default(''))

--- a/roles/agent/templates/beszel-agent.openrc.j2
+++ b/roles/agent/templates/beszel-agent.openrc.j2
@@ -1,0 +1,31 @@
+#!/sbin/openrc-run
+
+name="Beszel Agent"
+description="Beszel Agent Service"
+
+command="{{ agent_install_dir }}/beszel-agent"
+command_args="{{ agent_args | trim }}"
+command_user="{{ agent_user }}"
+command_background="yes"
+pidfile="/run/beszel-agent.pid"
+
+depend() {
+  need net
+}
+
+start_pre() {
+  export PORT="{{ agent_port }}"
+  export KEY="{{ agent_public_key }}"
+  {% if agent_hub_url %}
+  export HUB_URL="{{ agent_hub_url }}"
+  {% endif %}
+  {% if agent_token %}
+  export TOKEN="{{ agent_token }}"
+  {% endif %}
+  {% if agent_name %}
+  export SYSTEM_NAME="{{ agent_name }}"
+  {% endif %}
+  {% if agent_extra_filesystems %}
+  export EXTRA_FILESYSTEMS="{{ agent_extra_filesystems | join(',') }}"
+  {% endif %}
+}

--- a/roles/hub/defaults/main.yml
+++ b/roles/hub/defaults/main.yml
@@ -19,6 +19,9 @@ hub_data_dir: /var/lib/beszel
 hub_user: beszel
 # Custom arguments for the Beszel hub
 hub_args: ""
+# Service manager used to manage the Beszel hub service
+# When null, the role sets it from ansible_facts.service_mgr (e.g. systemd or openrc)
+hub_service_manager: null
 # Enable the Beszel hub systemd service on boot
 hub_service_enabled: true
 # State of the Beszel hub systemd service

--- a/roles/hub/handlers/main.yml
+++ b/roles/hub/handlers/main.yml
@@ -3,8 +3,30 @@
 - name: Reload systemd configuration
   ansible.builtin.systemd_service:
     daemon_reload: true
+  when: hub_service_manager == 'systemd'
 
 - name: Restart Beszel hub systemd service
   ansible.builtin.service:
     name: beszel-hub
     state: restarted
+  when: hub_service_manager == 'systemd'
+  listen: Restart Beszel hub service
+
+- name: Restart Beszel hub service (OpenRC) | Restart service
+  ansible.builtin.command: rc-service beszel-hub restart
+  when: hub_service_manager == 'openrc'
+  listen: Restart Beszel hub service
+  async: 120
+  poll: 0
+  changed_when: true
+
+- name: Restart Beszel hub service (OpenRC) | Wait for service to be running
+  ansible.builtin.command: rc-service beszel-hub status
+  register: hub_openrc_restart_status
+  until: hub_openrc_restart_status.rc == 0
+  retries: 12
+  delay: 5
+  failed_when: false
+  when: hub_service_manager == 'openrc'
+  listen: Restart Beszel hub service
+  changed_when: false

--- a/roles/hub/tasks/hub_absent.yml
+++ b/roles/hub/tasks/hub_absent.yml
@@ -1,14 +1,55 @@
 ---
 # absent tasks file for hub
+- name: hub_absent | Set service manager from detected facts when not explicitly set
+  ansible.builtin.set_fact:
+    hub_svc_mgr_candidate: "{{ hub_service_manager | default(ansible_facts.service_mgr) }}"
+
+- name: hub_absent | Set hub_service_manager from candidate
+  ansible.builtin.set_fact:
+    hub_service_manager: >-
+      {{ hub_svc_mgr_candidate if hub_svc_mgr_candidate in ['systemd', 'openrc']
+         else 'auto' }}
+
+- name: hub_absent | Detect service manager from system when facts are ambiguous
+  when: hub_service_manager == 'auto'
+  block:
+    - name: hub_absent | Check for systemd and OpenRC
+      ansible.builtin.stat:
+        path: "{{ item }}"
+      register: _hub_service_mgr_paths
+      loop:
+        - /etc/systemd/system
+        - /sbin/openrc
+        - /sbin/openrc-run
+
+    - name: hub_absent | Set has_systemd and has_openrc from filesystem
+      ansible.builtin.set_fact:
+        hub_has_systemd: "{{ _hub_service_mgr_paths.results[0].stat.isdir | default(false) }}"
+        hub_has_openrc: >-
+          {{ _hub_service_mgr_paths.results[1].stat.exists | default(false)
+             or _hub_service_mgr_paths.results[2].stat.exists | default(false) }}
+
+    - name: hub_absent | Set hub_service_manager from filesystem
+      ansible.builtin.set_fact:
+        hub_service_manager: >-
+          {{ 'systemd' if hub_has_systemd else ('openrc' if hub_has_openrc else 'systemd') }}
+
 - name: hub_absent | Stop Beszel hub systemd service
+  when: hub_service_manager == 'systemd'
   ansible.builtin.service:
     name: beszel-hub
     state: stopped
 
 - name: hub_absent | Remove Beszel hub systemd service
+  when: hub_service_manager == 'systemd'
   ansible.builtin.file:
     path: /etc/systemd/system/beszel-hub.service
     state: absent
+
+- name: hub_absent | Include OpenRC absent tasks
+  when: hub_service_manager == 'openrc'
+  ansible.builtin.include_tasks:
+    file: hub_absent_openrc.yml
 
 - name: hub_absent | Remove user for the Beszel hub
   ansible.builtin.user:

--- a/roles/hub/tasks/hub_absent_openrc.yml
+++ b/roles/hub/tasks/hub_absent_openrc.yml
@@ -1,0 +1,18 @@
+---
+# openrc absent tasks for hub
+- name: hub_absent | Stop Beszel hub service
+  ansible.builtin.command: rc-service beszel-hub stop
+  register: hub_openrc_stop_result
+  failed_when: hub_openrc_stop_result.rc not in [0, 1]
+  changed_when: true
+
+- name: hub_absent | Remove Beszel hub OpenRC service script
+  ansible.builtin.file:
+    path: /etc/init.d/beszel-hub
+    state: absent
+
+- name: hub_absent | Remove Beszel hub from default runlevel
+  ansible.builtin.command: rc-update del beszel-hub default
+  register: hub_rc_update_del_result
+  failed_when: hub_rc_update_del_result.rc not in [0, 1]
+  changed_when: true

--- a/roles/hub/tasks/hub_present.yml
+++ b/roles/hub/tasks/hub_present.yml
@@ -1,7 +1,47 @@
 ---
 # present tasks file for hub
+- name: hub_present | Set service manager from detected facts when not explicitly set
+  ansible.builtin.set_fact:
+    hub_svc_mgr_candidate: "{{ hub_service_manager | default(ansible_facts.service_mgr) }}"
+
+- name: hub_present | Set hub_service_manager from candidate
+  ansible.builtin.set_fact:
+    hub_service_manager: >-
+      {{ hub_svc_mgr_candidate if hub_svc_mgr_candidate in ['systemd', 'openrc']
+         else 'auto' }}
+
+- name: hub_present | Detect service manager from system when facts are ambiguous
+  when: hub_service_manager == 'auto'
+  block:
+    - name: hub_present | Check for systemd and OpenRC
+      ansible.builtin.stat:
+        path: "{{ item }}"
+      register: _hub_service_mgr_paths
+      loop:
+        - /etc/systemd/system
+        - /sbin/openrc
+        - /sbin/openrc-run
+
+    - name: hub_present | Set has_systemd and has_openrc from filesystem
+      ansible.builtin.set_fact:
+        hub_has_systemd: "{{ _hub_service_mgr_paths.results[0].stat.isdir | default(false) }}"
+        hub_has_openrc: >-
+          {{ _hub_service_mgr_paths.results[1].stat.exists | default(false)
+             or _hub_service_mgr_paths.results[2].stat.exists | default(false) }}
+
+    - name: hub_present | Set hub_service_manager from filesystem
+      ansible.builtin.set_fact:
+        hub_service_manager: >-
+          {{ 'systemd' if hub_has_systemd else ('openrc' if hub_has_openrc else 'systemd') }}
+
 - name: hub_present | Gather package facts
   ansible.builtin.package_facts:
+
+- name: hub_present | Ensure GNU tar is available for tarball extraction
+  when: ansible_os_family == 'Alpine'
+  ansible.builtin.package:
+    name: tar
+    state: present
 
 - name: hub_present | Determine Beszel hub architecture
   ansible.builtin.set_fact:
@@ -30,7 +70,7 @@
 
 - name: hub_present | Extract Beszel hub tarball
   when: not ansible_check_mode
-  notify: Restart Beszel hub systemd service
+  notify: Restart Beszel hub service
   ansible.builtin.unarchive:
     src: /tmp/beszel-hub.tar.gz
     dest: "{{ hub_install_dir }}"
@@ -56,17 +96,29 @@
     owner: "{{ hub_user }}"
     group: "{{ hub_user }}"
 
+- name: hub_present | Fail on unsupported service manager for Beszel hub
+  ansible.builtin.fail:
+    msg: "Service manager {{ hub_service_manager }} is not supported for the Beszel hub. Supported values are 'systemd' and 'openrc'."
+  when: hub_service_manager not in ['systemd', 'openrc']
+
 - name: hub_present | Install Beszel hub systemd service
+  when: hub_service_manager == 'systemd'
   notify: Reload systemd configuration
   ansible.builtin.template:
     src: beszel-hub.service.j2
     dest: /etc/systemd/system/beszel-hub.service
     mode: u=rw,g=r,o=r
 
+- name: hub_present | Include OpenRC service tasks
+  when: hub_service_manager == 'openrc'
+  ansible.builtin.include_tasks:
+    file: hub_present_openrc.yml
+
 - name: hub_present | Flush handlers
   ansible.builtin.meta: flush_handlers
 
 - name: hub_present | Start the Beszel hub systemd service
+  when: hub_service_manager == 'systemd'
   ansible.builtin.service:
     name: beszel-hub
     enabled: "{{ hub_service_enabled }}"

--- a/roles/hub/tasks/hub_present_openrc.yml
+++ b/roles/hub/tasks/hub_present_openrc.yml
@@ -1,0 +1,39 @@
+---
+# openrc present tasks for hub
+- name: hub_present | Ensure OpenRC default runlevel is booted
+  ansible.builtin.command: openrc boot
+  changed_when: false
+
+- name: hub_present | Install Beszel hub OpenRC service script
+  ansible.builtin.template:
+    src: beszel-hub.openrc.j2
+    dest: /etc/init.d/beszel-hub
+    mode: u=rwx,g=rx,o=rx
+
+- name: hub_present | Ensure Beszel hub added to default runlevel
+  ansible.builtin.command: rc-update add beszel-hub default
+  args:
+    creates: /etc/runlevels/default/beszel-hub
+
+- name: hub_present | Flush handlers
+  ansible.builtin.meta: flush_handlers
+
+- name: hub_present | Get OpenRC service status
+  ansible.builtin.command: rc-service beszel-hub status
+  register: hub_openrc_status
+  changed_when: false
+  failed_when: false
+  retries: 12
+  delay: 3
+  until: hub_openrc_status.rc != 8
+
+- name: hub_present | Start the Beszel hub service
+  ansible.builtin.command: "rc-service beszel-hub {{ 'stop' if hub_service_state == 'stopped' else 'start' }}"
+  when:
+    - (hub_service_state == 'started' and hub_openrc_status.rc not in [0, 8]) or (hub_service_state == 'stopped' and hub_openrc_status.rc == 0)
+  register: hub_openrc_start
+  changed_when: false
+  failed_when: >
+    hub_openrc_start.rc != 0
+    and 'stopped by something else' not in (hub_openrc_start.stderr | default(''))
+    and 'already starting' not in (hub_openrc_start.stderr | default(''))

--- a/roles/hub/templates/beszel-hub.openrc.j2
+++ b/roles/hub/templates/beszel-hub.openrc.j2
@@ -1,0 +1,20 @@
+#!/sbin/openrc-run
+
+name="Beszel Hub"
+description="Beszel Hub Service"
+
+command="{{ hub_install_dir }}/beszel"
+command_args="serve --http 0.0.0.0:{{ hub_port }} {{ hub_args }}"
+command_user="{{ hub_user }}"
+command_background="yes"
+pidfile="/run/beszel-hub.pid"
+directory="{{ hub_data_dir }}"
+
+depend() {
+  need net
+}
+
+start_pre() {
+  touch /run/beszel-hub.pid
+  chown {{ hub_user }}:{{ hub_user }} /run/beszel-hub.pid
+}

--- a/tests/sanity/ignore-2.17.txt
+++ b/tests/sanity/ignore-2.17.txt
@@ -1,0 +1,2 @@
+roles/agent/templates/beszel-agent.openrc.j2 shebang!skip
+roles/hub/templates/beszel-hub.openrc.j2 shebang!skip

--- a/tests/sanity/ignore-2.18.txt
+++ b/tests/sanity/ignore-2.18.txt
@@ -1,0 +1,2 @@
+roles/agent/templates/beszel-agent.openrc.j2 shebang!skip
+roles/hub/templates/beszel-hub.openrc.j2 shebang!skip

--- a/tests/sanity/ignore-2.19.txt
+++ b/tests/sanity/ignore-2.19.txt
@@ -1,0 +1,2 @@
+roles/agent/templates/beszel-agent.openrc.j2 shebang!skip
+roles/hub/templates/beszel-hub.openrc.j2 shebang!skip

--- a/tests/sanity/ignore-2.20.txt
+++ b/tests/sanity/ignore-2.20.txt
@@ -1,0 +1,2 @@
+roles/agent/templates/beszel-agent.openrc.j2 shebang!skip
+roles/hub/templates/beszel-hub.openrc.j2 shebang!skip

--- a/tests/sanity/ignore-2.21.txt
+++ b/tests/sanity/ignore-2.21.txt
@@ -1,0 +1,2 @@
+roles/agent/templates/beszel-agent.openrc.j2 shebang!skip
+roles/hub/templates/beszel-hub.openrc.j2 shebang!skip

--- a/uv.lock
+++ b/uv.lock
@@ -266,7 +266,7 @@ wheels = [
 
 [[package]]
 name = "community-beszel"
-version = "0.7.0"
+version = "0.7.1"
 source = { virtual = "." }
 dependencies = [
     { name = "ansible-core" },


### PR DESCRIPTION
**Add OpenRC support and agent_uid default for agent**

* Add OpenRC support and agent_uid default for agent and hub roles

Support managing the Beszel agent and hub with OpenRC (in addition to
systemd) for systems like Alpine. Service manager is auto-detected when
possible. Add a default for the `agent_uid` role variable so the beszel
user is created without a fixed UID unless overridden. Add Molecule
scenarios `agent_openrc` and `hub_openrc` to test OpenRC-based
deployments.

Co-Authored-By: Cursor Auto <noreply@cursor.com>

* chore: prepare `0.7.2` release

---------

Co-authored-by: Cursor Auto <noreply@cursor.com>
Co-authored-by: Pascal Dulieu <2935785+pascalo7@users.noreply.github.com>