### PR TITLE
Added options to monit GPU & SMART with variables

### DIFF
--- a/roles/agent/README.md
+++ b/roles/agent/README.md
@@ -89,26 +89,26 @@ Extra filesystems to be monitored by the Beszel binary agent. Configures the [EX
 
 ```yaml
 agent_smart_disks: []
-# Example with disks to be SMART monitored by the Beszel binary agent
+# Example with disks to be S.M.A.R.T monitored by the Beszel binary agent
 agent_smart_disks:
   - /dev/sda
   - /dev/nvme0n1
 ```
 
-SMART devices to be monitored by the Beszel binary agent. Configures the [Capabilities, smartmontools and DeviceAllow](https://beszel.dev/guide/smart-data) in the agent systemd unit file.  
+Disks to be S.M.A.R.T monitored by the Beszel binary agent. Installs `smartmontools` and configures the [Capabilities and DeviceAllow](https://beszel.dev/guide/smart-data) in the agent systemd unit file.
 
 > [!IMPORTANT]
-> If NVME drives do not show up, please follow the [troubleshooting](https://beszel.dev/guide/smart-data#adjust-nvme-device-permissions) documentation.
+> If NVMe drives do not show up in Beszel hub, please follow the [troubleshooting](https://beszel.dev/guide/smart-data#adjust-nvme-device-permissions) documentation.
 
 ```yaml
 agent_smart_interval: 1h
 ```
 
-Interval between SMART checks by the Beszel binary agent. 
+Interval between S.M.A.R.T checks by the Beszel binary agent.
 
 ```yaml
 agent_gpus: []
-# Example for Nvidia GPU
+# Example for NVIDIA GPU
 agent_gpus:
   - path: /dev/nvidia0
     type: nvidia
@@ -122,7 +122,7 @@ agent_gpus:
     type: intel
 ```
 
-GPU devices to be monitored by the Beszel binary agent. Installs the required packages depending the GPU type, and configures the [DeviceAllow](https://beszel.dev/guide/gpu) in the agent systemd unit file.
+GPU devices to be monitored by the Beszel binary agent. Installs the required packages depending on the GPU type, and configures the [DeviceAllow](https://beszel.dev/guide/gpu) in the agent systemd unit file.
 
 ```yaml
 agent_service_enabled: true

--- a/roles/agent/README.md
+++ b/roles/agent/README.md
@@ -111,7 +111,7 @@ agent_gpus: []
 # Example for Nvidia GPU
 agent_gpus:
   - path: /dev/nvidia0
-    type: nvidia0
+    type: nvidia
 # Example for AMD GPU
 agent_gpus:
   - path: /dev/card0

--- a/roles/agent/README.md
+++ b/roles/agent/README.md
@@ -88,6 +88,41 @@ agent_extra_filesystems:
 Extra filesystems to be monitored by the Beszel binary agent. Configures the [EXTRA_FILESYSTEMS](https://beszel.dev/guide/additional-disks#binary-agent) environment variable in the agent systemd unit file.
 
 ```yaml
+agent_smart_disks: []
+# Example with disks to be SMART monitored by Beszel
+agent_smart_disks:
+  - /dev/sda
+  - /dev/nvme0n1
+```
+
+SMART devices to be monitored by the Beszel binary agent. Configures the [Capabilities, smartmontools and DeviceAllow](https://beszel.dev/guide/smart-data) in the agent systemd unit file.  
+If NVME drives aren't showing up, please follow [this troubleshooting in Beszel documentation](https://beszel.dev/guide/smart-data#adjust-nvme-device-permissions)
+
+```yaml
+agent_smart_interval: 1h
+```
+
+Interval between SMART checks by the Beszel binary agent. 
+
+```yaml
+agent_gpus: []
+# Example for Nvidia GPU
+agent_gpus:
+  - path: /dev/nvidia0
+    type: nvidia0
+# Example for AMD GPU
+agent_gpus:
+  - path: /dev/card0
+    type: amd
+# Example for Intel GPU
+agent_gpus:
+  - path: /dev/card0
+    type: intel
+```
+
+GPU devices to be monitored by the Beszel binary agent. Installs the required packages depending the GPU type, and configures the [DeviceAllow](https://beszel.dev/guide/gpu) in the agent systemd unit file.
+
+```yaml
 agent_service_enabled: true
 ```
 

--- a/roles/agent/README.md
+++ b/roles/agent/README.md
@@ -96,7 +96,8 @@ agent_smart_disks:
 ```
 
 SMART devices to be monitored by the Beszel binary agent. Configures the [Capabilities, smartmontools and DeviceAllow](https://beszel.dev/guide/smart-data) in the agent systemd unit file.  
-If NVME drives aren't showing up, please follow [this troubleshooting in Beszel documentation](https://beszel.dev/guide/smart-data#adjust-nvme-device-permissions)
+> [!IMPORTANT]
+> If NVME drives aren't showing up, please follow [this troubleshooting in Beszel documentation](https://beszel.dev/guide/smart-data#adjust-nvme-device-permissions)
 
 ```yaml
 agent_smart_interval: 1h

--- a/roles/agent/README.md
+++ b/roles/agent/README.md
@@ -89,7 +89,7 @@ Extra filesystems to be monitored by the Beszel binary agent. Configures the [EX
 
 ```yaml
 agent_smart_disks: []
-# Example with disks to be SMART monitored by Beszel
+# Example with disks to be SMART monitored by the Beszel binary agent
 agent_smart_disks:
   - /dev/sda
   - /dev/nvme0n1

--- a/roles/agent/README.md
+++ b/roles/agent/README.md
@@ -96,8 +96,9 @@ agent_smart_disks:
 ```
 
 SMART devices to be monitored by the Beszel binary agent. Configures the [Capabilities, smartmontools and DeviceAllow](https://beszel.dev/guide/smart-data) in the agent systemd unit file.  
+
 > [!IMPORTANT]
-> If NVME drives aren't showing up, please follow [this troubleshooting in Beszel documentation](https://beszel.dev/guide/smart-data#adjust-nvme-device-permissions)
+> If NVME drives do not show up, please follow the [troubleshooting](https://beszel.dev/guide/smart-data#adjust-nvme-device-permissions) documentation.
 
 ```yaml
 agent_smart_interval: 1h

--- a/roles/agent/defaults/main.yml
+++ b/roles/agent/defaults/main.yml
@@ -27,6 +27,10 @@ agent_service_state: started
 # Extra filesystems to be monitored by the Beszel binary agent
 agent_extra_filesystems: []
 # URL of the Beszel hub for the Beszel binary agent to connect to
+agent_smart_disks: []
+# List of disks to be monitored by Beszel binary
+agent_gpu_list: []
+# List of GPU to be monitored by Beszel binary
 agent_hub_url: ""
 # Universal token used for automatic registration with Beszel hub
 # Either agent_public_key OR agent_token must be provided

--- a/roles/agent/defaults/main.yml
+++ b/roles/agent/defaults/main.yml
@@ -30,7 +30,7 @@ agent_extra_filesystems: []
 agent_smart_interval: 1h
 # List of disks to be monitored by the Beszel binary agent
 agent_smart_disks: []
-# List of GPUs to be monitored by Beszel binary
+# List of GPUs to be monitored by the Beszel binary agent
 # Each GPU should be a dict with 'path' and 'type' keys.
 # Example:
 #   agent_gpus:

--- a/roles/agent/defaults/main.yml
+++ b/roles/agent/defaults/main.yml
@@ -26,6 +26,8 @@ agent_service_enabled: true
 agent_service_state: started
 # Extra filesystems to be monitored by the Beszel binary agent
 agent_extra_filesystems: []
+# Interval for SMART checks
+agent_smart_interval: 1h
 # List of disks to be monitored by Beszel binary
 agent_smart_disks: []
 # List of GPUs to be monitored by Beszel binary

--- a/roles/agent/defaults/main.yml
+++ b/roles/agent/defaults/main.yml
@@ -28,7 +28,7 @@ agent_service_state: started
 agent_extra_filesystems: []
 # Interval for SMART checks
 agent_smart_interval: 1h
-# List of disks to be monitored by Beszel binary
+# List of disks to be monitored by the Beszel binary agent
 agent_smart_disks: []
 # List of GPUs to be monitored by Beszel binary
 # Each GPU should be a dict with 'path' and 'type' keys.

--- a/roles/agent/defaults/main.yml
+++ b/roles/agent/defaults/main.yml
@@ -29,7 +29,15 @@ agent_extra_filesystems: []
 # List of disks to be monitored by Beszel binary
 agent_smart_disks: []
 # List of GPUs to be monitored by Beszel binary
-agent_gpu_list: []
+# Each GPU should be a dict with 'path' and 'type' keys.
+# Example:
+#   agent_gpus:
+#     - path: /dev/nvidia0
+#       type: nvidia
+#     - path: /dev/dri/card0
+#       type: intel
+# Supported types: nvidia, intel, amd
+agent_gpus: []
 # URL of the Beszel hub for the Beszel binary agent to connect to
 agent_hub_url: ""
 # Universal token used for automatic registration with Beszel hub

--- a/roles/agent/defaults/main.yml
+++ b/roles/agent/defaults/main.yml
@@ -26,11 +26,11 @@ agent_service_enabled: true
 agent_service_state: started
 # Extra filesystems to be monitored by the Beszel binary agent
 agent_extra_filesystems: []
-# URL of the Beszel hub for the Beszel binary agent to connect to
-agent_smart_disks: []
 # List of disks to be monitored by Beszel binary
+agent_smart_disks: []
+# List of GPUs to be monitored by Beszel binary
 agent_gpu_list: []
-# List of GPU to be monitored by Beszel binary
+# URL of the Beszel hub for the Beszel binary agent to connect to
 agent_hub_url: ""
 # Universal token used for automatic registration with Beszel hub
 # Either agent_public_key OR agent_token must be provided

--- a/roles/agent/defaults/main.yml
+++ b/roles/agent/defaults/main.yml
@@ -26,11 +26,11 @@ agent_service_enabled: true
 agent_service_state: started
 # Extra filesystems to be monitored by the Beszel binary agent
 agent_extra_filesystems: []
-# Interval for SMART checks
+# Interval between S.M.A.R.T checks by the Beszel binary agent
 agent_smart_interval: 1h
-# List of disks to be monitored by the Beszel binary agent
+# Disks to be S.M.A.R.T monitored by the Beszel binary agent
 agent_smart_disks: []
-# List of GPUs to be monitored by the Beszel binary agent
+# GPU devices to be monitored by the Beszel binary agent
 # Each GPU should be a dict with 'path' and 'type' keys.
 # Example:
 #   agent_gpus:

--- a/roles/agent/tasks/agent_present.yml
+++ b/roles/agent/tasks/agent_present.yml
@@ -75,6 +75,40 @@
     append: true
     state: present
 
+- name: agent_present | Install smartmontools for SMART disk monitoring
+  when: agent_smart_disks | length > 0
+  ansible.builtin.package:
+    name: smartmontools
+    state: present
+
+- name: agent_present | Add beszel user to disk group for SMART disk access
+  when: agent_smart_disks | length > 0
+  ansible.builtin.user:
+    name: "{{ agent_user }}"
+    groups: disk
+    append: true
+
+- name: agent_present | Check if nvidia-smi is already installed
+  when: agent_gpus | length > 0 and agent_gpus | selectattr('type', 'equalto', 'nvidia') | list | length > 0
+  ansible.builtin.command: which nvidia-smi
+  register: nvidia_smi_check
+  changed_when: false
+  failed_when: false
+
+- name: agent_present | Install NVIDIA GPU monitoring tools
+  when: agent_gpus | length > 0 and agent_gpus | selectattr('type', 'equalto', 'nvidia') | list | length > 0 and nvidia_smi_check.rc != 0
+  ansible.builtin.package:
+    name:
+      - nvidia-smi
+      - nvtop
+    state: present
+
+- name: agent_present | Install Intel GPU monitoring tools
+  when: agent_gpus | length > 0 and agent_gpus | selectattr('type', 'equalto', 'intel') | list | length > 0
+  ansible.builtin.package:
+    name: intel-gpu-tools
+    state: present
+
 - name: agent_present | Install Beszel binary agent systemd service
   notify:
     - Reload systemd configuration

--- a/roles/agent/tasks/agent_present.yml
+++ b/roles/agent/tasks/agent_present.yml
@@ -12,6 +12,16 @@
       Required: agent_public_key must always be provided.
       If agent_token is provided, then agent_hub_url must also be provided.
 
+- name: agent_present | Assert agent_gpus entries have required keys
+  when: agent_gpus | length > 0
+  ansible.builtin.assert:
+    that:
+      - agent_gpus | rejectattr('path', 'defined') | list | length == 0
+      - agent_gpus | rejectattr('type', 'defined') | list | length == 0
+    fail_msg: >-
+      Each entry in agent_gpus must have both 'path' and 'type' keys.
+      Example: { path: /dev/nvidia0, type: nvidia }
+
 - name: agent_present | Gather package facts
   ansible.builtin.package_facts:
 

--- a/roles/agent/tasks/agent_present.yml
+++ b/roles/agent/tasks/agent_present.yml
@@ -85,13 +85,13 @@
     append: true
     state: present
 
-- name: agent_present | Install smartmontools for SMART disk monitoring
+- name: agent_present | Install smartmontools for S.M.A.R.T disk monitoring
   when: agent_smart_disks | length > 0
   ansible.builtin.package:
     name: smartmontools
     state: present
 
-- name: agent_present | Add beszel user to disk group for SMART disk access
+- name: agent_present | Add beszel user to disk group for S.M.A.R.T disk access
   when: agent_smart_disks | length > 0
   ansible.builtin.user:
     name: "{{ agent_user }}"

--- a/roles/agent/tasks/agent_present.yml
+++ b/roles/agent/tasks/agent_present.yml
@@ -89,14 +89,19 @@
     append: true
 
 - name: agent_present | Check if nvidia-smi is already installed
-  when: agent_gpus | length > 0 and agent_gpus | selectattr('type', 'equalto', 'nvidia') | list | length > 0
+  when:
+    - agent_gpus | length > 0
+    - agent_gpus | selectattr('type', 'equalto', 'nvidia') | list | length > 0
   ansible.builtin.command: which nvidia-smi
-  register: nvidia_smi_check
+  register: agent_nvidia_smi_check
   changed_when: false
   failed_when: false
 
 - name: agent_present | Install NVIDIA GPU monitoring tools
-  when: agent_gpus | length > 0 and agent_gpus | selectattr('type', 'equalto', 'nvidia') | list | length > 0 and nvidia_smi_check.rc != 0
+  when:
+    - agent_gpus | length > 0
+    - agent_gpus | selectattr('type', 'equalto', 'nvidia') | list | length > 0
+    - agent_nvidia_smi_check.rc != 0
   ansible.builtin.package:
     name:
       - nvidia-smi
@@ -104,7 +109,9 @@
     state: present
 
 - name: agent_present | Install Intel GPU monitoring tools
-  when: agent_gpus | length > 0 and agent_gpus | selectattr('type', 'equalto', 'intel') | list | length > 0
+  when:
+    - agent_gpus | length > 0
+    - agent_gpus | selectattr('type', 'equalto', 'intel') | list | length > 0
   ansible.builtin.package:
     name: intel-gpu-tools
     state: present

--- a/roles/agent/templates/beszel-agent.service.j2
+++ b/roles/agent/templates/beszel-agent.service.j2
@@ -23,7 +23,18 @@ Environment="EXTRA_FILESYSTEMS={{ agent_extra_filesystems | join(',') }}"
 Restart=on-failure
 RestartSec=5
 StateDirectory=beszel-agent
-
+{% if agent_smart_disks | length > 0 %}
+AmbientCapabilities=CAP_SYS_RAWIO CAP_SYS_ADMIN
+CapabilityBoundingSet=CAP_SYS_RAWIO CAP_SYS_ADMIN
+{% for disks in agent_smart_disks %}
+DeviceAllow={{ disks }} r
+{% endfor %}
+{% endif %}
+{% if agent_gpu_list | length > 0 %}
+{% for gpu in agent_gpu_list %}
+DeviceAllow={{ gpu }} r
+{% endfor %}
+{% endif %}
 # Security/sandboxing settings
 KeyringMode=private
 LockPersonality=yes

--- a/roles/agent/templates/beszel-agent.service.j2
+++ b/roles/agent/templates/beszel-agent.service.j2
@@ -28,8 +28,11 @@ AmbientCapabilities={% if agent_smart_disks | length > 0 %}CAP_SYS_RAWIO CAP_SYS
 
 {% endif %}
 {% if agent_gpus | length > 0 %}
+{% if agent_gpus | selectattr('type', 'equalto', 'nvidia') | list | length > 0 %}
+DeviceAllow=/dev/nvidiactl rw
+{% endif %}
 {% for gpu in agent_gpus %}
-DeviceAllow={{ gpu.path }} r
+DeviceAllow={{ gpu.path }} rw
 {% endfor %}
 {% endif %}
 {% if agent_smart_disks | length > 0 %}

--- a/roles/agent/templates/beszel-agent.service.j2
+++ b/roles/agent/templates/beszel-agent.service.j2
@@ -24,24 +24,26 @@ Environment="EXTRA_FILESYSTEMS={{ agent_extra_filesystems | join(',') }}"
 Restart=on-failure
 RestartSec=5
 StateDirectory=beszel-agent
-{% if agent_smart_disks | length > 0 or agent_gpus | selectattr('type', 'equalto', 'intel') | list | length > 0 %}
-AmbientCapabilities={% if agent_smart_disks | length > 0 %}CAP_SYS_RAWIO CAP_SYS_ADMIN{% endif %}{% if agent_smart_disks | length > 0 and agent_gpus | selectattr('type', 'equalto', 'intel') | list | length > 0 %} {% endif %}{% if agent_gpus | selectattr('type', 'equalto', 'intel') | list | length > 0 %}CAP_PERFMON{% endif %}
-
+{# Pre-compute device type flags to avoid repeated filter expressions #}
+{% set _has_smart = agent_smart_disks | length > 0 %}
+{% set _has_nvidia = agent_gpus | selectattr('type', 'equalto', 'nvidia') | list | length > 0 %}
+{% set _has_intel = agent_gpus | selectattr('type', 'equalto', 'intel') | list | length > 0 %}
+{% set _caps = (['CAP_SYS_RAWIO', 'CAP_SYS_ADMIN'] if _has_smart else []) + (['CAP_PERFMON'] if _has_intel else []) %}
+{% if _caps %}
+AmbientCapabilities={{ _caps | join(' ') }}
 {% endif %}
-{% if agent_gpus | length > 0 %}
-{% if agent_gpus | selectattr('type', 'equalto', 'nvidia') | list | length > 0 %}
+{% if _has_smart %}
+CapabilityBoundingSet={{ _caps | join(' ') }}
+{% endif %}
+{% if _has_nvidia %}
 DeviceAllow=/dev/nvidiactl rw
 {% endif %}
 {% for gpu in agent_gpus %}
 DeviceAllow={{ gpu.path }} rw
 {% endfor %}
-{% endif %}
-{% if agent_smart_disks | length > 0 %}
-CapabilityBoundingSet=CAP_SYS_RAWIO CAP_SYS_ADMIN
 {% for disk in agent_smart_disks %}
 DeviceAllow={{ disk }} r
 {% endfor %}
-{% endif %}
 # Security/sandboxing settings
 KeyringMode=private
 LockPersonality=yes

--- a/roles/agent/templates/beszel-agent.service.j2
+++ b/roles/agent/templates/beszel-agent.service.j2
@@ -23,16 +23,19 @@ Environment="EXTRA_FILESYSTEMS={{ agent_extra_filesystems | join(',') }}"
 Restart=on-failure
 RestartSec=5
 StateDirectory=beszel-agent
+{% if agent_smart_disks | length > 0 or agent_gpus | selectattr('type', 'equalto', 'intel') | list | length > 0 %}
+AmbientCapabilities={% if agent_smart_disks | length > 0 %}CAP_SYS_RAWIO CAP_SYS_ADMIN{% endif %}{% if agent_smart_disks | length > 0 and agent_gpus | selectattr('type', 'equalto', 'intel') | list | length > 0 %} {% endif %}{% if agent_gpus | selectattr('type', 'equalto', 'intel') | list | length > 0 %}CAP_PERFMON{% endif %}
+
+{% endif %}
+{% if agent_gpus | length > 0 %}
+{% for gpu in agent_gpus %}
+DeviceAllow={{ gpu.path }} r
+{% endfor %}
+{% endif %}
 {% if agent_smart_disks | length > 0 %}
-AmbientCapabilities=CAP_SYS_RAWIO CAP_SYS_ADMIN
 CapabilityBoundingSet=CAP_SYS_RAWIO CAP_SYS_ADMIN
 {% for disk in agent_smart_disks %}
 DeviceAllow={{ disk }} r
-{% endfor %}
-{% endif %}
-{% if agent_gpu_list | length > 0 %}
-{% for gpu in agent_gpu_list %}
-DeviceAllow={{ gpu }} r
 {% endfor %}
 {% endif %}
 # Security/sandboxing settings

--- a/roles/agent/templates/beszel-agent.service.j2
+++ b/roles/agent/templates/beszel-agent.service.j2
@@ -26,8 +26,8 @@ StateDirectory=beszel-agent
 {% if agent_smart_disks | length > 0 %}
 AmbientCapabilities=CAP_SYS_RAWIO CAP_SYS_ADMIN
 CapabilityBoundingSet=CAP_SYS_RAWIO CAP_SYS_ADMIN
-{% for disks in agent_smart_disks %}
-DeviceAllow={{ disks }} r
+{% for disk in agent_smart_disks %}
+DeviceAllow={{ disk }} r
 {% endfor %}
 {% endif %}
 {% if agent_gpu_list | length > 0 %}

--- a/roles/agent/templates/beszel-agent.service.j2
+++ b/roles/agent/templates/beszel-agent.service.j2
@@ -8,6 +8,7 @@ User={{ agent_user }}
 ExecStart={{ agent_install_dir }}/beszel-agent {{ agent_args | trim }}
 Environment="PORT={{ agent_port }}"
 Environment="KEY={{ agent_public_key }}"
+Environment="SMART_INTERVAL={{ agent_smart_interval }}"
 {% if agent_hub_url %}
 Environment="HUB_URL={{ agent_hub_url }}"
 {% endif %}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added the ability to add SMART & GPU options to the service file using Ansible env : 
https://beszel.dev/guide/smart-data
https://beszel.dev/guide/gpu
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
SMART & GPU monitoring
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
According to the documentation of Beszel, monitoring of SMART drives needs some capabilities and DeviceAllow, as GPU monit needs DeviceAllow. 
I added them into the templates :
- If the agent_smart_disk is set, it'll add the needed capabilities & devices
- if the agent_gpu_list is set, it'll add the device
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
╭─   ~/ansible   master !1 ?3                                                                       11s  ansible ansible@uzurka-ansible  23:06:32 ─╮
╰─❯ grep -A 1 "gpu\|disk" host_vars/zeus/beszel.yml                                                                                                      ─╯
agent_smart_disks:
  - /dev/sda
agent_gpu_list:
  - /dev/gpu0
```
```
TASK [community.beszel.agent : agent_present | Install Beszel binary agent systemd service] ****************************************************************
--- before: /etc/systemd/system/beszel-agent.service
+++ after: /home/ansible/.ansible/tmp/ansible-local-105817eehqs804/tmp0_t0011z/beszel-agent.service.j2
@@ -13,6 +13,10 @@
 Restart=on-failure
 RestartSec=5
 StateDirectory=beszel-agent
+AmbientCapabilities=CAP_SYS_RAWIO CAP_SYS_ADMIN
+CapabilityBoundingSet=CAP_SYS_RAWIO CAP_SYS_ADMIN
+DeviceAllow=/dev/sda r
+DeviceAllow=/dev/gpu0 r
 # Security/sandboxing settings
 KeyringMode=private
 LockPersonality=yes

changed: [zeus]
```
