### PR TITLE
feat(community.beszel.hub): add variable to configure server host binding

### DIFF
--- a/changelogs/fragments/hub-server-host-variable.yml
+++ b/changelogs/fragments/hub-server-host-variable.yml
@@ -1,4 +1,3 @@
 ---
 minor_changes:
-  - community.beszel.hub - Add variable to customize hub server host to listen on.
-
+  - community.beszel.hub - Add hub_bind_address to customize the bind address to listen on.

--- a/changelogs/fragments/hub-server-host-variable.yml
+++ b/changelogs/fragments/hub-server-host-variable.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - community.beszel.hub - Add variable to customize hub server host to listen on.
+

--- a/roles/hub/README.md
+++ b/roles/hub/README.md
@@ -20,7 +20,7 @@ Version of the Beszel hub to install. Can be a specific version from GitHub (e.g
 hub_bind_address: 0.0.0.0
 ```
 
-Host for the Beszel hub to listen on.
+Bind address for the Beszel hub to listen on.
 
 ```yaml
 hub_port: 8090

--- a/roles/hub/README.md
+++ b/roles/hub/README.md
@@ -17,7 +17,7 @@ hub_version: latest
 Version of the Beszel hub to install. Can be a specific version from GitHub (e.g., `v0.9.1`).
 
 ```yaml
-hub_host: 0.0.0.0
+hub_bind_address: 0.0.0.0
 ```
 
 Host for the Beszel hub to listen on.

--- a/roles/hub/README.md
+++ b/roles/hub/README.md
@@ -17,6 +17,12 @@ hub_version: latest
 Version of the Beszel hub to install. Can be a specific version from GitHub (e.g., `v0.9.1`).
 
 ```yaml
+hub_host: 0.0.0.0
+```
+
+Host for the Beszel hub to listen on.
+
+```yaml
 hub_port: 8090
 ```
 

--- a/roles/hub/defaults/main.yml
+++ b/roles/hub/defaults/main.yml
@@ -9,6 +9,8 @@ hub_state: present
 # Version of the Beszel hub to install
 # Can be a specific version from GitHub (e.g., v0.9.1)
 hub_version: latest
+# Host for the Beszel hub to listen on
+hub_port: 0.0.0.0
 # Port for the Beszel hub to listen on
 hub_port: 8090
 # Directory to install the Beszel hub into

--- a/roles/hub/defaults/main.yml
+++ b/roles/hub/defaults/main.yml
@@ -9,8 +9,8 @@ hub_state: present
 # Version of the Beszel hub to install
 # Can be a specific version from GitHub (e.g., v0.9.1)
 hub_version: latest
-# Host for the Beszel hub to listen on
-hub_port: 0.0.0.0
+# Bind address for the Beszel hub to listen on
+hub_bind_address: 0.0.0.0
 # Port for the Beszel hub to listen on
 hub_port: 8090
 # Directory to install the Beszel hub into

--- a/roles/hub/templates/beszel-hub.service.j2
+++ b/roles/hub/templates/beszel-hub.service.j2
@@ -8,7 +8,7 @@ Restart=always
 RestartSec=3
 User={{ hub_user }}
 WorkingDirectory={{ hub_data_dir }}
-ExecStart={{ hub_install_dir }}/beszel serve --http {{ hub_host }}:{{ hub_port }} {{ hub_args }}
+ExecStart={{ hub_install_dir }}/beszel serve --http {{ hub_bind_address }}:{{ hub_port }} {{ hub_args }}
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/hub/templates/beszel-hub.service.j2
+++ b/roles/hub/templates/beszel-hub.service.j2
@@ -8,7 +8,7 @@ Restart=always
 RestartSec=3
 User={{ hub_user }}
 WorkingDirectory={{ hub_data_dir }}
-ExecStart={{ hub_install_dir }}/beszel serve --http 0.0.0.0:{{ hub_port }} {{ hub_args }}
+ExecStart={{ hub_install_dir }}/beszel serve --http {{ hub_host }}:{{ hub_port }} {{ hub_args }}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
##### SUMMARY
Add a variable to be able to customize the server host to listen on.  

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- hub role service template

##### ADDITIONAL INFORMATION
The idea was to be able to make the server only accessible in localhost when server is behind an HTTP proxy.

I'm novice in ansible role/collection development. I hope I don't miss something.