### PR TITLE
release: community.beszel 1.0.0

### DIFF
--- a/.claude/skills/changelogs/SKILL.md
+++ b/.claude/skills/changelogs/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: changelogs
+user-invokable: true
+description: "This skill should be used when the user asks to 'generate a changelog', 'create a changelog fragment', 'run antsibull-changelog', or wants to prepare a release changelog. It inspects commits on the current branch, categorises them using antsibull-changelog fragment categories, writes a changelog fragment YAML, and runs the changelog generation command."
+---
+
+You are executing the `changelogs` skill. Follow these steps precisely.
+
+## Step 1: Pre-flight checks
+
+1. Read `galaxy.yml` and extract the `version`, `namespace`, and `name` fields. Set `FQCN_BASE = "<namespace>.<name>"`.
+2. Read `changelogs/changelog.yaml` and check whether that version already has an entry under `releases:`.
+3. If the version already exists in the changelog:
+   - Use `AskUserQuestion` to ask: "Version <version> already has a release entry in changelogs/changelog.yaml. Should I remove it and the corresponding fragment file before proceeding? (yes/no)"
+   - If yes: Remove the version's entry from `changelogs/changelog.yaml` using the Edit tool, and delete `changelogs/fragments/<version>.yml` using Bash (`rm`).
+   - If no: Stop and inform the user the skill was aborted.
+
+## Step 2: Discover commits on the current branch
+
+Run these commands with the Bash tool:
+
+```bash
+git rev-parse --abbrev-ref HEAD
+```
+Save the output as `<branch-name>` — this will be used as the fragment filename.
+
+```bash
+git log main..HEAD --oneline
+```
+List all commits not yet merged into main. If there are no commits, stop and tell the user there are no commits ahead of main.
+
+```bash
+git log main..HEAD --format="%H %s%n%b"
+```
+Get full commit subjects and bodies for better analysis.
+
+```bash
+git diff main..HEAD --name-only
+```
+Get all changed files to help detect which component/role is affected.
+
+Ignore any commits whose subject contains `[skip ci]` or starts with `Merge `.
+
+## Step 3: Map commits to antsibull-changelog categories
+
+Use conventional commit prefixes as the primary signal:
+
+| Commit prefix                                                | Fragment category         |
+| ------------------------------------------------------------ | ------------------------- |
+| `feat:` / `feature:`                                         | `minor_changes`           |
+| `fix:` / `bugfix:`                                           | `bugfixes`                |
+| `security:`                                                  | `security_fixes`          |
+| `BREAKING CHANGE` in body, or `!` before `:` (e.g. `feat!:`) | `breaking_changes`        |
+| `deprecate:` / `deprecated:`                                 | `deprecated_features`     |
+| `remove:` / `removed:`                                       | `removed_features`        |
+| `docs:` / `chore:` / `ci:` / `test:` / `refactor:`           | `trivial` — skip entirely |
+
+For each non-trivial commit:
+
+1. **Determine the component** using `FQCN_BASE` derived from `galaxy.yml` and the file paths changed by the commit. Apply these rules **in order**:
+
+   | File path pattern                        | Component prefix                      |
+   | ---------------------------------------- | ------------------------------------- |
+   | `roles/<role_name>/…`                    | `<FQCN_BASE>.<role_name> - `          |
+   | `plugins/modules/<module_name>.py`       | `<FQCN_BASE>.<module_name> - `        |
+   | `plugins/<plugin_type>/<plugin_name>.py` | `<FQCN_BASE>.<plugin_name> - `        |
+   | `plugins/module_utils/…`                 | `<FQCN_BASE> - `                      |
+   | Everything else                          | *(no prefix — collection-level)*      |
+
+   - `<role_name>` is the directory name directly under `roles/`.
+   - `<module_name>` is the filename without `.py`.
+   - `<plugin_name>` is the filename without `.py`.
+   - If the commit message scope (e.g. `feat(community.beszel.agent):`) names a component, use that instead.
+   - If the commit touches files spanning multiple components, omit the prefix.
+
+2. **Write the description**: Use the commit subject (stripped of the `type:` prefix and leading space). Capitalise the first letter. Do not end with a period.
+
+3. If a commit contains `BREAKING CHANGE:` in its body, extract that text as the description for a `breaking_changes` entry (in addition to or instead of the subject-derived entry).
+
+## Step 4: Generate the fragment file
+
+Write `changelogs/fragments/<branch-name>.yml` using the Write tool with this structure:
+
+```yaml
+---
+release_summary: |
+  Release <version> of the Ansible community collection for Beszel.
+
+<category>:
+  - <component><description>
+```
+
+Rules:
+- Always include `release_summary`.
+- Only include categories that have at least one entry.
+- List entries in the order: `breaking_changes`, `security_fixes`, `minor_changes`, `bugfixes`, `deprecated_features`, `removed_features`.
+- Each entry is a YAML list item (starts with `  - `).
+- If a component prefix applies, include it before the description (e.g. `community.beszel.agent - Add foo variable`).
+
+Example:
+
+```yaml
+---
+release_summary: |
+  Release 0.8.0 of the Ansible community collection for Beszel.
+
+minor_changes:
+  - community.beszel.agent - Add support for custom agent port configuration.
+  - community.beszel.hub - Add hub_tls_cert role variable for TLS certificate path.
+
+bugfixes:
+  - community.beszel.agent - Fix idempotency issue when agent_token is not set.
+```
+
+## Step 5: Run changelog generation
+
+Run:
+
+```bash
+uv run antsibull-changelog release -v
+```
+
+Report the full command output to the user. If the command fails, show the error and suggest the user check:
+- The fragment YAML syntax
+- Whether `uv` and `antsibull-changelog` are installed
+- Whether the version in `galaxy.yml` matches what antsibull-changelog expects
+
+## Step 6: Verify CHANGELOG.md and CHANGELOG.rst were updated
+
+After a successful run, read both `CHANGELOG.md` and `CHANGELOG.rst` and confirm that the new version's release section is present in each file. Specifically check that:
+
+1. `CHANGELOG.md` contains a heading for the new version (e.g. `## v<version>`) and the entries from the fragment.
+2. `CHANGELOG.rst` contains a heading for the new version (e.g. `v<version>`) and the entries from the fragment.
+
+If either file is missing the new version's section, report it as a warning and suggest the user re-run `uv run antsibull-changelog release -v` manually or check the antsibull-changelog configuration.

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: commit
+user-invokable: true
+description: "This skill should be used when the user asks to 'commit', 'create a commit', or 'git commit'. It creates conventional commits with FQCN scopes for Ansible collection content (roles, modules, plugins) and automatically splits changed files into separate, focused commits when they belong to different collection components."
+---
+
+You are executing the `commit` skill. Follow these steps precisely.
+
+## Step 1: Resolve FQCN base
+
+Read `galaxy.yml` and extract the `namespace` and `name` fields.
+Set `FQCN_BASE = "<namespace>.<name>"` (e.g. `community.beszel`).
+
+## Step 2: Discover changed files
+
+Run `git status --short` with the Bash tool to list all modified, staged, and untracked files.
+
+Categorise each file as:
+- **Staged** — lines starting with a non-space first character (e.g. `M `, `A `, `D `)
+- **Unstaged** — lines starting with a space in the first column (e.g. ` M`, ` D`)
+- **Untracked** — lines starting with `??`
+
+If nothing is changed, stop and inform the user there are no changes to commit.
+
+## Step 3: Group files by component
+
+Assign each changed file to a component bucket using these rules **in order**:
+
+| File path pattern                                                  | Component scope                 | Example                      |
+| ------------------------------------------------------------------ | ------------------------------- | ---------------------------- |
+| `roles/<role_name>/…`                                              | `<FQCN_BASE>.<role_name>`       | `community.beszel.agent`     |
+| `plugins/modules/<module_name>.py`                                 | `<FQCN_BASE>.<module_name>`     | `community.beszel.system`    |
+| `plugins/<plugin_type>/<plugin_name>.py`                           | `<FQCN_BASE>.<plugin_name>`     | `community.beszel.my_filter` |
+| `plugins/module_utils/…`                                           | `<FQCN_BASE>` (collection-wide) | `community.beszel`           |
+| Everything else (galaxy.yml, docs, tests, ci, changelogs, meta, …) | `(none)` — collection-level     | —                            |
+
+- `<role_name>` is the directory name directly under `roles/`.
+- `<module_name>` is the filename without `.py`.
+- `<plugin_type>` is the subdirectory under `plugins/` (e.g. `filter`, `lookup`, `callback`).
+- `<plugin_name>` is the filename without `.py`.
+- Never hard-code component names; always derive them from the file path.
+
+After grouping, if **multiple components** are affected:
+- List the proposed groupings to the user (which files go in which commit).
+- Use `AskUserQuestion` to ask: "I found changes across multiple components and will create separate commits. Does this look right?\n\n<groupings>\n\nProceed? (yes/no or provide corrections)"
+- If the user says no or provides corrections, adjust the groupings accordingly.
+
+## Step 4: For each component group (in order)
+
+Repeat the following sub-steps for each group:
+
+### 4a: Infer commit type
+
+Read the diff for the files in this group (`git diff HEAD -- <files>` for unstaged, `git diff --cached -- <files>` for staged) to inform your inference. Use the following mapping to select the commit type:
+
+| Commit type prefix                                 | antsibull-changelog category |
+| -------------------------------------------------- | ---------------------------- |
+| `feat:` / `feature:`                               | `minor_changes`              |
+| `fix:` / `bugfix:`                                 | `bugfixes`                   |
+| `security:`                                        | `security_fixes`             |
+| `feat!:` or `BREAKING CHANGE` in body              | `breaking_changes`           |
+| `deprecate:` / `deprecated:`                       | `deprecated_features`        |
+| `remove:` / `removed:`                             | `removed_features`           |
+| `docs:` / `chore:` / `ci:` / `test:` / `refactor:` | `trivial`                    |
+
+If the type is ambiguous, use `AskUserQuestion` to ask:
+"What type of change is this for `<component>`? (feat/fix/docs/chore/refactor/ci/test/security/deprecate/remove/breaking)"
+
+### 4b: Draft commit message
+
+Follow conventional commits format:
+- **With FQCN scope**: `<type>(<fqcn>): <imperative short description>`
+- **Collection-level (no scope)**: `<type>: <imperative short description>`
+
+Rules:
+- Subject line ≤ 72 characters
+- Lowercase after the colon and space
+- No trailing period
+- Use imperative mood (e.g. "add", "fix", "remove" — not "added", "fixes")
+- For breaking changes, append a blank line and `BREAKING CHANGE: <explanation>` in the body
+
+Examples:
+```
+feat(community.beszel.agent): add support for custom agent port
+fix(community.beszel.hub): correct idempotency when hub token unset
+feat!: drop support for Ansible < 2.15
+
+BREAKING CHANGE: Ansible 2.14 and earlier are no longer supported.
+docs: update README with new installation steps
+```
+
+### 4c: Confirm with user
+
+Use `AskUserQuestion` to present the proposed commit message and ask for approval:
+
+"Proposed commit for `<component>`:\n\n```\n<message>\n```\n\nApprove, or provide an edited message?"
+
+If the user provides an edited message, use their version exactly.
+
+### 4d: Stage files
+
+Run `git add <file1> <file2> …` for all files in this component group.
+
+### 4e: Create the commit
+
+Run:
+```bash
+git commit -m "$(cat <<'EOF'
+<approved message>
+EOF
+)"
+```
+
+### 4f: Confirm
+
+Run `git log -1 --oneline` and show the output to the user.
+
+## Step 5: Summary
+
+After all commits are created, run:
+```bash
+git log --oneline -<n>
+```
+where `<n>` is the total number of commits just created. Display the output so the user can see all commits at a glance.

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -53,15 +53,15 @@ Repeat the following sub-steps for each group:
 
 Read the diff for the files in this group (`git diff HEAD -- <files>` for unstaged, `git diff --cached -- <files>` for staged) to inform your inference. Use the following mapping to select the commit type:
 
-| Commit type prefix                                 | antsibull-changelog category |
-| -------------------------------------------------- | ---------------------------- |
-| `feat:` / `feature:`                               | `minor_changes`              |
-| `fix:` / `bugfix:`                                 | `bugfixes`                   |
-| `security:`                                        | `security_fixes`             |
-| `feat!:` or `BREAKING CHANGE` in body              | `breaking_changes`           |
-| `deprecate:` / `deprecated:`                       | `deprecated_features`        |
-| `remove:` / `removed:`                             | `removed_features`           |
-| `docs:` / `chore:` / `ci:` / `test:` / `refactor:` | `trivial`                    |
+| Commit type prefix                                           | antsibull-changelog category |
+| ------------------------------------------------------------ | ---------------------------- |
+| `feat:` / `feature:`                                         | `minor_changes`              |
+| `fix:` / `bugfix:`                                           | `bugfixes`                   |
+| `security:`                                                  | `security_fixes`             |
+| `BREAKING CHANGE` in body, or `!` before `:` (e.g. `feat!:`) | `breaking_changes`           |
+| `deprecate:` / `deprecated:`                                 | `deprecated_features`        |
+| `remove:` / `removed:`                                       | `removed_features`           |
+| `docs:` / `chore:` / `ci:` / `test:` / `refactor:`           | `trivial`                    |
 
 If the type is ambiguous, use `AskUserQuestion` to ask:
 "What type of change is this for `<component>`? (feat/fix/docs/chore/refactor/ci/test/security/deprecate/remove/breaking)"

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -6,12 +6,19 @@ description: "This skill should be used when the user asks to 'commit', 'create 
 
 You are executing the `commit` skill. Follow these steps precisely.
 
-## Step 1: Resolve FQCN base
+## Step 1: Determine Co-Authored-By
+
+Identify the model you are currently running as from your system context.
+Format it as `Claude <Family> <Version>` — e.g. `Claude Sonnet 4.6`, `Claude Opus 4.6`, `Claude Haiku 4.5`.
+Set `CO_AUTHOR = "Claude <Family> <Version> <noreply@anthropic.com>"`.
+This trailer will be appended to every commit created in this session.
+
+## Step 2: Resolve FQCN base
 
 Read `galaxy.yml` and extract the `namespace` and `name` fields.
 Set `FQCN_BASE = "<namespace>.<name>"` (e.g. `community.beszel`).
 
-## Step 2: Discover changed files
+## Step 3: Discover changed files
 
 Run `git status --short` with the Bash tool to list all modified, staged, and untracked files.
 
@@ -22,7 +29,7 @@ Categorise each file as:
 
 If nothing is changed, stop and inform the user there are no changes to commit.
 
-## Step 3: Group files by component
+## Step 4: Group files by component
 
 Assign each changed file to a component bucket using these rules **in order**:
 
@@ -45,11 +52,11 @@ After grouping, if **multiple components** are affected:
 - Use `AskUserQuestion` to ask: "I found changes across multiple components and will create separate commits. Does this look right?\n\n<groupings>\n\nProceed? (yes/no or provide corrections)"
 - If the user says no or provides corrections, adjust the groupings accordingly.
 
-## Step 4: For each component group (in order)
+## Step 5: For each component group (in order)
 
 Repeat the following sub-steps for each group:
 
-### 4a: Infer commit type
+### 5a: Infer commit type
 
 Read the diff for the files in this group (`git diff HEAD -- <files>` for unstaged, `git diff --cached -- <files>` for staged) to inform your inference. Use the following mapping to select the commit type:
 
@@ -66,7 +73,7 @@ Read the diff for the files in this group (`git diff HEAD -- <files>` for unstag
 If the type is ambiguous, use `AskUserQuestion` to ask:
 "What type of change is this for `<component>`? (feat/fix/docs/chore/refactor/ci/test/security/deprecate/remove/breaking)"
 
-### 4b: Draft commit message
+### 5b: Draft commit message
 
 Follow conventional commits format:
 - **With FQCN scope**: `<type>(<fqcn>): <imperative short description>`
@@ -78,18 +85,24 @@ Rules:
 - No trailing period
 - Use imperative mood (e.g. "add", "fix", "remove" — not "added", "fixes")
 - For breaking changes, append a blank line and `BREAKING CHANGE: <explanation>` in the body
+- Always append a blank line followed by `Co-Authored-By: <CO_AUTHOR>` (from Step 1) at the end of every message
 
 Examples:
 ```
 feat(community.beszel.agent): add support for custom agent port
-fix(community.beszel.hub): correct idempotency when hub token unset
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+```
+
+```
 feat!: drop support for Ansible < 2.15
 
 BREAKING CHANGE: Ansible 2.14 and earlier are no longer supported.
-docs: update README with new installation steps
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
 ```
 
-### 4c: Confirm with user
+### 5c: Confirm with user
 
 Use `AskUserQuestion` to present the proposed commit message and ask for approval:
 
@@ -97,25 +110,29 @@ Use `AskUserQuestion` to present the proposed commit message and ask for approva
 
 If the user provides an edited message, use their version exactly.
 
-### 4d: Stage files
+### 5d: Stage files
 
 Run `git add <file1> <file2> …` for all files in this component group.
 
-### 4e: Create the commit
+### 5e: Create the commit
 
 Run:
 ```bash
 git commit -m "$(cat <<'EOF'
 <approved message>
+
+Co-Authored-By: Claude <ModelName> <noreply@anthropic.com>
 EOF
 )"
 ```
 
-### 4f: Confirm
+Where `<ModelName>` is the model name resolved in Step 1 (e.g. `Claude Sonnet 4.6`).
+
+### 5f: Confirm
 
 Run `git log -1 --oneline` and show the output to the user.
 
-## Step 5: Summary
+## Step 6: Summary
 
 After all commits are created, run:
 ```bash

--- a/.github/workflows/ansible-molecule.yml
+++ b/.github/workflows/ansible-molecule.yml
@@ -7,17 +7,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Docker Compose
-        uses: docker/setup-compose-action@v1
+        uses: docker/setup-compose-action@8cccb8c14b6500aaffebff1aa49c502c34d2e5e6 # v2.1.0
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version-file: pyproject.toml
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Set up Python environment
         run: uv sync --only-group test
@@ -28,9 +28,9 @@ jobs:
           uv run ansible-galaxy collection install community-beszel-*.tar.gz
 
       - name: Run Molecule scenarios
-        run: |
-          cd extensions
-          uv run molecule test --all
         env:
           PY_COLORS: 1
           ANSIBLE_FORCE_COLOR: 1
+        run: |
+          cd extensions
+          uv run molecule test --all

--- a/.github/workflows/antsibull-nox.yml
+++ b/.github/workflows/antsibull-nox.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
   # Run CI once per day (at 07:30 UTC)
   schedule:
-    - cron: '30 7 * * *'
+    - cron: "30 7 * * *"
   workflow_dispatch:
 
 jobs:
@@ -16,11 +16,11 @@ jobs:
     name: "Run nox"
     steps:
       - name: Check out collection
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Run nox
-        uses: ansible-community/antsibull-nox@main
+        uses: ansible-community/antsibull-nox@78992c026d3acb6d2bc0f888e62489521282aab0 # v1.5.0
 
   ansible-test:
-    uses: ansible-community/antsibull-nox/.github/workflows/reusable-nox-matrix.yml@main
+    uses: ansible-community/antsibull-nox/.github/workflows/reusable-nox-matrix.yml@78992c026d3acb6d2bc0f888e62489521282aab0 # 1.5.0

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ ansible.cfg
 .vscode/settings.json
 ansible_collections/
 .ruff_cache/
+.DS_Store
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,47 +2,75 @@
 
 **Topics**
 
-- <a href="#v0-7-1">v0\.7\.1</a>
+- <a href="#v1-0-0">v1\.0\.0</a>
     - <a href="#release-summary">Release Summary</a>
-    - <a href="#bugfixes">Bugfixes</a>
-- <a href="#v0-7-0">v0\.7\.0</a>
-    - <a href="#release-summary-1">Release Summary</a>
     - <a href="#minor-changes">Minor Changes</a>
-- <a href="#v0-6-2">v0\.6\.2</a>
+    - <a href="#breaking-changes--porting-guide">Breaking Changes / Porting Guide</a>
+    - <a href="#bugfixes">Bugfixes</a>
+- <a href="#v0-7-1">v0\.7\.1</a>
+    - <a href="#release-summary-1">Release Summary</a>
+    - <a href="#bugfixes-1">Bugfixes</a>
+- <a href="#v0-7-0">v0\.7\.0</a>
     - <a href="#release-summary-2">Release Summary</a>
     - <a href="#minor-changes-1">Minor Changes</a>
-- <a href="#v0-6-1">v0\.6\.1</a>
+- <a href="#v0-6-2">v0\.6\.2</a>
     - <a href="#release-summary-3">Release Summary</a>
     - <a href="#minor-changes-2">Minor Changes</a>
-- <a href="#v0-6-0">v0\.6\.0</a>
+- <a href="#v0-6-1">v0\.6\.1</a>
     - <a href="#release-summary-4">Release Summary</a>
     - <a href="#minor-changes-3">Minor Changes</a>
-    - <a href="#new-modules">New Modules</a>
-- <a href="#v0-5-0">v0\.5\.0</a>
+- <a href="#v0-6-0">v0\.6\.0</a>
     - <a href="#release-summary-5">Release Summary</a>
     - <a href="#minor-changes-4">Minor Changes</a>
-- <a href="#v0-4-0">v0\.4\.0</a>
+    - <a href="#new-modules">New Modules</a>
+- <a href="#v0-5-0">v0\.5\.0</a>
     - <a href="#release-summary-6">Release Summary</a>
     - <a href="#minor-changes-5">Minor Changes</a>
-- <a href="#v0-3-0">v0\.3\.0</a>
+- <a href="#v0-4-0">v0\.4\.0</a>
     - <a href="#release-summary-7">Release Summary</a>
     - <a href="#minor-changes-6">Minor Changes</a>
-    - <a href="#new-modules-1">New Modules</a>
-- <a href="#v0-2-0">v0\.2\.0</a>
+- <a href="#v0-3-0">v0\.3\.0</a>
     - <a href="#release-summary-8">Release Summary</a>
     - <a href="#minor-changes-7">Minor Changes</a>
-- <a href="#v0-1-0">v0\.1\.0</a>
+    - <a href="#new-modules-1">New Modules</a>
+- <a href="#v0-2-0">v0\.2\.0</a>
     - <a href="#release-summary-9">Release Summary</a>
+    - <a href="#minor-changes-8">Minor Changes</a>
+- <a href="#v0-1-0">v0\.1\.0</a>
+    - <a href="#release-summary-10">Release Summary</a>
 
-<a id="v0-7-1"></a>
-## v0\.7\.1
+<a id="v1-0-0"></a>
+## v1\.0\.0
 
 <a id="release-summary"></a>
 ### Release Summary
 
-Release 0\.7\.1 of the Ansible community collection for Beszel\.
+Release 1\.0\.0 of the Ansible community collection for Beszel\.
+
+<a id="minor-changes"></a>
+### Minor Changes
+
+* community\.beszel\.hub \- Add hub\_uid and hub\_user\_groups variables
+
+<a id="breaking-changes--porting-guide"></a>
+### Breaking Changes / Porting Guide
+
+* community\.beszel\.agent \- Replace auto docker\-group detection with configurable agent\_user\_groups and agent\_docker\_host variables
 
 <a id="bugfixes"></a>
+### Bugfixes
+
+* Remove append flag from user creation tasks in agent and hub roles
+
+<a id="v0-7-1"></a>
+## v0\.7\.1
+
+<a id="release-summary-1"></a>
+### Release Summary
+
+Release 0\.7\.1 of the Ansible community collection for Beszel\.
+
+<a id="bugfixes-1"></a>
 ### Bugfixes
 
 * community\.beszel\.agent \- Skip tarball extraction tasks when running in Ansible check mode to prevent failures on fresh systems where the tarball has not been downloaded yet\.
@@ -51,12 +79,12 @@ Release 0\.7\.1 of the Ansible community collection for Beszel\.
 <a id="v0-7-0"></a>
 ## v0\.7\.0
 
-<a id="release-summary-1"></a>
+<a id="release-summary-2"></a>
 ### Release Summary
 
 Release 0\.7\.0 of the Ansible community collection for Beszel\.
 
-<a id="minor-changes"></a>
+<a id="minor-changes-1"></a>
 ### Minor Changes
 
 * community\.beszel\.agent \- Add \'agent\_uid\' role variable to specify the UID for the agent user\.
@@ -65,12 +93,12 @@ Release 0\.7\.0 of the Ansible community collection for Beszel\.
 <a id="v0-6-2"></a>
 ## v0\.6\.2
 
-<a id="release-summary-2"></a>
+<a id="release-summary-3"></a>
 ### Release Summary
 
 Release 0\.6\.2 of the Ansible community collection for Beszel\.
 
-<a id="minor-changes-1"></a>
+<a id="minor-changes-2"></a>
 ### Minor Changes
 
 * community\.beszel\.agent \- Create beszel user as a system user without home directory\.
@@ -79,12 +107,12 @@ Release 0\.6\.2 of the Ansible community collection for Beszel\.
 <a id="v0-6-1"></a>
 ## v0\.6\.1
 
-<a id="release-summary-3"></a>
+<a id="release-summary-4"></a>
 ### Release Summary
 
 Release 0\.6\.1 of the Ansible community collection for Beszel\.
 
-<a id="minor-changes-2"></a>
+<a id="minor-changes-3"></a>
 ### Minor Changes
 
 * community\.beszel\.agent \- Ensure the beszel\-agent systemd service is restarted to apply changes correctly\.
@@ -92,12 +120,12 @@ Release 0\.6\.1 of the Ansible community collection for Beszel\.
 <a id="v0-6-0"></a>
 ## v0\.6\.0
 
-<a id="release-summary-4"></a>
+<a id="release-summary-5"></a>
 ### Release Summary
 
 Release 0\.6\.0 of the Ansible community collection for Beszel\.
 
-<a id="minor-changes-3"></a>
+<a id="minor-changes-4"></a>
 ### Minor Changes
 
 * Add GitHub Actions workflow for running antsibull\-nox\.
@@ -112,12 +140,12 @@ Release 0\.6\.0 of the Ansible community collection for Beszel\.
 <a id="v0-5-0"></a>
 ## v0\.5\.0
 
-<a id="release-summary-5"></a>
+<a id="release-summary-6"></a>
 ### Release Summary
 
 Release 0\.5\.0 of the Ansible community collection for Beszel\.
 
-<a id="minor-changes-4"></a>
+<a id="minor-changes-5"></a>
 ### Minor Changes
 
 * Add AGENTS\.md to instruct AI agents how to perform development tasks within this project\.
@@ -130,12 +158,12 @@ Release 0\.5\.0 of the Ansible community collection for Beszel\.
 <a id="v0-4-0"></a>
 ## v0\.4\.0
 
-<a id="release-summary-6"></a>
+<a id="release-summary-7"></a>
 ### Release Summary
 
 Release 0\.4\.0 of the Ansible community collection for Beszel\.
 
-<a id="minor-changes-5"></a>
+<a id="minor-changes-6"></a>
 ### Minor Changes
 
 * community\.beszel\.agent \- Add \'agent\_name\' role variable\. Name of the host in the Beszel hub that is used instead of the system hostname when registering with the Beszel hub \(v0\.13\.0\+\)\.
@@ -143,12 +171,12 @@ Release 0\.4\.0 of the Ansible community collection for Beszel\.
 <a id="v0-3-0"></a>
 ## v0\.3\.0
 
-<a id="release-summary-7"></a>
+<a id="release-summary-8"></a>
 ### Release Summary
 
 Release 0\.3\.0 of the Ansible community collection for Beszel\.
 
-<a id="minor-changes-6"></a>
+<a id="minor-changes-7"></a>
 ### Minor Changes
 
 * community\.beszel\.agent \- Add \'agent\_token\' role variable\. Universal token used by the Beszel binary agent to automatically register with Beszel hub\.
@@ -163,12 +191,12 @@ Release 0\.3\.0 of the Ansible community collection for Beszel\.
 <a id="v0-2-0"></a>
 ## v0\.2\.0
 
-<a id="release-summary-8"></a>
+<a id="release-summary-9"></a>
 ### Release Summary
 
 Release 0\.2\.0 of the Ansible community collection for Beszel\.
 
-<a id="minor-changes-7"></a>
+<a id="minor-changes-8"></a>
 ### Minor Changes
 
 * community\.beszel\.agent \- Add \'agent\_hub\_url\' role variable\. URL of the Beszel hub for the Beszel binary agent to connect to\.
@@ -176,7 +204,7 @@ Release 0\.2\.0 of the Ansible community collection for Beszel\.
 <a id="v0-1-0"></a>
 ## v0\.1\.0
 
-<a id="release-summary-9"></a>
+<a id="release-summary-10"></a>
 ### Release Summary
 
 Release 0\.1\.0 of the Ansible community collection for Beszel\.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Release 1\.0\.0 of the Ansible community collection for Beszel\.
 <a id="minor-changes"></a>
 ### Minor Changes
 
+* community\.beszel\.hub \- Add hub\_bind\_address to customize the bind address to listen on\.
 * community\.beszel\.hub \- Add hub\_uid and hub\_user\_groups variables
 
 <a id="breaking-changes--porting-guide"></a>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Release 1\.0\.0 of the Ansible community collection for Beszel\.
 <a id="minor-changes"></a>
 ### Minor Changes
 
+* community\.beszel\.agent \- Add GPU and S\.M\.A\.R\.T disk monitoring support with agent\_gpus and agent\_smart\_disks variables\.
 * community\.beszel\.hub \- Add hub\_bind\_address to customize the bind address to listen on\.
 * community\.beszel\.hub \- Add hub\_uid and hub\_user\_groups variables
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Release 1.0.0 of the Ansible community collection for Beszel.
 Minor Changes
 -------------
 
+- community.beszel.agent - Add GPU and S.M.A.R.T disk monitoring support with agent_gpus and agent_smart_disks variables.
 - community.beszel.hub - Add hub_bind_address to customize the bind address to listen on.
 - community.beszel.hub - Add hub_uid and hub_user_groups variables
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Release 1.0.0 of the Ansible community collection for Beszel.
 Minor Changes
 -------------
 
+- community.beszel.hub - Add hub_bind_address to customize the bind address to listen on.
 - community.beszel.hub - Add hub_uid and hub_user_groups variables
 
 Breaking Changes / Porting Guide

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,29 @@ Ansible community collection for Beszel Release Notes
 
 .. contents:: Topics
 
+v1.0.0
+======
+
+Release Summary
+---------------
+
+Release 1.0.0 of the Ansible community collection for Beszel.
+
+Minor Changes
+-------------
+
+- community.beszel.hub - Add hub_uid and hub_user_groups variables
+
+Breaking Changes / Porting Guide
+--------------------------------
+
+- community.beszel.agent - Replace auto docker-group detection with configurable agent_user_groups and agent_docker_host variables
+
+Bugfixes
+--------
+
+- Remove append flag from user creation tasks in agent and hub roles
+
 v0.7.1
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -149,6 +149,8 @@ releases:
       bugfixes:
         - Remove append flag from user creation tasks in agent and hub roles
       minor_changes:
+        - community.beszel.agent - Add GPU and S.M.A.R.T disk monitoring support with
+          agent_gpus and agent_smart_disks variables.
         - community.beszel.hub - Add hub_bind_address to customize the bind address
           to listen on.
         - community.beszel.hub - Add hub_uid and hub_user_groups variables

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -149,10 +149,12 @@ releases:
       bugfixes:
         - Remove append flag from user creation tasks in agent and hub roles
       minor_changes:
+        - community.beszel.hub - Add hub_bind_address to customize the bind address
+          to listen on.
         - community.beszel.hub - Add hub_uid and hub_user_groups variables
       release_summary: 'Release 1.0.0 of the Ansible community collection for Beszel.
 
         '
     fragments:
       - 1.0.0.yml
-    release_date: '2026-03-21'
+    release_date: '2026-03-22'

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -141,3 +141,18 @@ releases:
     fragments:
       - 0.7.1.yml
     release_date: '2026-02-23'
+  1.0.0:
+    changes:
+      breaking_changes:
+        - community.beszel.agent - Replace auto docker-group detection with configurable
+          agent_user_groups and agent_docker_host variables
+      bugfixes:
+        - Remove append flag from user creation tasks in agent and hub roles
+      minor_changes:
+        - community.beszel.hub - Add hub_uid and hub_user_groups variables
+      release_summary: 'Release 1.0.0 of the Ansible community collection for Beszel.
+
+        '
+    fragments:
+      - 1.0.0.yml
+    release_date: '2026-03-21'

--- a/changelogs/fragments/1.0.0.yml
+++ b/changelogs/fragments/1.0.0.yml
@@ -6,6 +6,7 @@ breaking_changes:
   - community.beszel.agent - Replace auto docker-group detection with configurable agent_user_groups and agent_docker_host variables
 
 minor_changes:
+  - community.beszel.agent - Add GPU and S.M.A.R.T disk monitoring support with agent_gpus and agent_smart_disks variables.
   - community.beszel.hub - Add hub_uid and hub_user_groups variables
   - community.beszel.hub - Add hub_bind_address to customize the bind address to listen on.
 

--- a/changelogs/fragments/1.0.0.yml
+++ b/changelogs/fragments/1.0.0.yml
@@ -1,0 +1,12 @@
+---
+release_summary: |
+  Release 1.0.0 of the Ansible community collection for Beszel.
+
+breaking_changes:
+  - community.beszel.agent - Replace auto docker-group detection with configurable agent_user_groups and agent_docker_host variables
+
+minor_changes:
+  - community.beszel.hub - Add hub_uid and hub_user_groups variables
+
+bugfixes:
+  - Remove append flag from user creation tasks in agent and hub roles

--- a/changelogs/fragments/1.0.0.yml
+++ b/changelogs/fragments/1.0.0.yml
@@ -7,6 +7,7 @@ breaking_changes:
 
 minor_changes:
   - community.beszel.hub - Add hub_uid and hub_user_groups variables
+  - community.beszel.hub - Add hub_bind_address to customize the bind address to listen on.
 
 bugfixes:
   - Remove append flag from user creation tasks in agent and hub roles

--- a/changelogs/fragments/hub-server-host-variable.yml
+++ b/changelogs/fragments/hub-server-host-variable.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - community.beszel.hub - Add hub_bind_address to customize the bind address to listen on.

--- a/changelogs/fragments/hub-server-host-variable.yml
+++ b/changelogs/fragments/hub-server-host-variable.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - community.beszel.hub - Add hub_bind_address to customize the bind address to listen on.

--- a/extensions/molecule/agent_airgap/create.yml
+++ b/extensions/molecule/agent_airgap/create.yml
@@ -18,15 +18,15 @@
     - name: Create | Determine architecture for Beszel agent
       ansible.builtin.set_fact:
         beszel_architecture: >-
-          {% if ansible_architecture == 'x86_64' %}
+          {% if ansible_facts['architecture'] == 'x86_64' %}
             amd64
-          {% elif ansible_architecture == 'aarch64' %}
+          {% elif ansible_facts['architecture'] == 'aarch64' %}
             arm64
-          {% elif ansible_architecture == 'arm64' %}
+          {% elif ansible_facts['architecture'] == 'arm64' %}
             arm64
-          {% elif ansible_architecture == 'armv6l' %}
+          {% elif ansible_facts['architecture'] == 'armv6l' %}
             arm
-          {% elif ansible_architecture == 'armv7l' %}
+          {% elif ansible_facts['architecture'] == 'armv7l' %}
             arm
           {% endif %}
 

--- a/extensions/molecule/docker-compose.yml
+++ b/extensions/molecule/docker-compose.yml
@@ -1,7 +1,7 @@
 ---
 services:
   beszel:
-    image: ghcr.io/henrygd/beszel/beszel:0.18.2
+    image: ghcr.io/henrygd/beszel/beszel:0.18.4
     container_name: beszel
     restart: unless-stopped
     environment:

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -3,7 +3,7 @@
 
 namespace: community
 name: beszel
-version: 0.7.1
+version: 1.0.0
 readme: README.md
 authors:
   - Daniel Brennand (github.com/dbrennand)
@@ -24,3 +24,10 @@ build_ignore:
   # https://docs.ansible.com/ansible/devel/dev_guide/developing_collections_distributing.html#ignoring-files-and-folders
   - .gitignore
   - changelogs/.plugin-cache.yaml
+  - .github
+  - .vscode
+  - .pre-commit-config.yaml
+  - .yamllint
+  - codecov.yml
+  - flake8.ini
+  - uv.lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "community-beszel"
-version = "0.8.0"
+version = "1.0.0"
 description = "Ansible community collection for Beszel."
 readme = "README.md"
 requires-python = ">=3.13, <3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "community-beszel"
-version = "0.7.1"
+version = "0.8.0"
 description = "Ansible community collection for Beszel."
 readme = "README.md"
 requires-python = ">=3.13, <3.14"
@@ -12,7 +12,7 @@ dependencies = [
 [dependency-groups]
 dev = [
     "antsibull-changelog[toml]>=0.34.0",
-    "antsibull-nox",
+    "antsibull-nox>=1.5.0",
     "codespell>=2.4.1",
     "prek>=0.2.20",
     {include-group = "test"},
@@ -20,8 +20,5 @@ dev = [
 test = [
     "molecule>=25.12.0",
     "molecule-plugins[docker]>=25.8.12",
-    "jmespath==1.0.1"
+    "jmespath>=1.0.1"
 ]
-
-[tool.uv.sources]
-antsibull-nox = { git = "https://github.com/ansible-community/antsibull-nox", rev = "a4f9b2f" }

--- a/roles/agent/README.md
+++ b/roles/agent/README.md
@@ -88,6 +88,43 @@ agent_extra_filesystems:
 Extra filesystems to be monitored by the Beszel binary agent. Configures the [EXTRA_FILESYSTEMS](https://beszel.dev/guide/additional-disks#binary-agent) environment variable in the agent systemd unit file.
 
 ```yaml
+agent_smart_disks: []
+# Example with disks to be S.M.A.R.T monitored by the Beszel binary agent
+agent_smart_disks:
+  - /dev/sda
+  - /dev/nvme0n1
+```
+
+Disks to be S.M.A.R.T monitored by the Beszel binary agent. Installs `smartmontools` and configures the [Capabilities and DeviceAllow](https://beszel.dev/guide/smart-data) in the agent systemd unit file.
+
+> [!IMPORTANT]
+> If NVMe drives do not show up in Beszel hub, please follow the [troubleshooting](https://beszel.dev/guide/smart-data#adjust-nvme-device-permissions) documentation.
+
+```yaml
+agent_smart_interval: 1h
+```
+
+Interval between S.M.A.R.T checks by the Beszel binary agent.
+
+```yaml
+agent_gpus: []
+# Example for NVIDIA GPU
+agent_gpus:
+  - path: /dev/nvidia0
+    type: nvidia
+# Example for AMD GPU
+agent_gpus:
+  - path: /dev/card0
+    type: amd
+# Example for Intel GPU
+agent_gpus:
+  - path: /dev/card0
+    type: intel
+```
+
+GPU devices to be monitored by the Beszel binary agent. Installs the required packages depending on the GPU type, and configures the [DeviceAllow](https://beszel.dev/guide/gpu) in the agent systemd unit file.
+
+```yaml
 agent_service_enabled: true
 ```
 

--- a/roles/agent/README.md
+++ b/roles/agent/README.md
@@ -64,7 +64,7 @@ agent_user: beszel
 Name of the user to create and run the Beszel binary agent as.
 
 ```yaml
-agent_uid: 1001
+# agent_uid: 1001
 ```
 
 UID for the agent user used to run the Beszel binary agent (chosen automatically by the OS if not specified).

--- a/roles/agent/README.md
+++ b/roles/agent/README.md
@@ -166,7 +166,7 @@ For an example of using the Beszel hub Pocketbase REST API to enable and retriev
 
 When using air-gapped deployment mode, place the `beszel-agent` binary in a `files/` directory in your playbook project on the Ansible Controller. The binary will be copied to the target host instead of being downloaded from GitHub. This mode is suitable for disconnected or restricted network environments.
 
-## Contributors
+## Original Contributors from [dbrennand/ansible-role-beszel](https://github.com/dbrennand/ansible-role-beszel)
 
 [Daniel Brennand](https://github.com/dbrennand)
 

--- a/roles/agent/README.md
+++ b/roles/agent/README.md
@@ -116,6 +116,26 @@ agent_airgap: false
 
 Enable air-gapped deployment mode. When set to `true`, the Beszel binary agent will be copied from the Ansible Controller to the target host instead of being downloaded from GitHub. The `beszel-agent` binary must be placed in a `files/` directory in your playbook project on the Ansible Controller. This mode is useful for disconnected or restricted network environments where direct internet access is not available.
 
+```yaml
+agent_user_groups: []
+# Example to restore old docker-group behaviour (not recommended):
+agent_user_groups:
+  - docker
+```
+
+> [!WARNING]
+> Adding the agent user to the `docker` group grants effective root access on the host and defeats the systemd sandboxing configured by this role. Use `agent_docker_host` with a socket proxy instead. See [issue #28](https://github.com/ansible-collections/community.beszel/issues/28) for context.
+
+Additional OS groups to add the Beszel binary agent user to. Defaults to an empty list (no supplementary groups). If you previously relied on automatic `docker` group membership (which was removed in favour of this variable), you can restore that behaviour by setting `agent_user_groups: [docker]`, but it is strongly discouraged.
+
+```yaml
+agent_docker_host: ""
+# Example (socket proxy):
+agent_docker_host: "tcp://localhost:2375"
+```
+
+Docker host URL for the Beszel binary agent to use for container statistics. When set, a `DOCKER_HOST` environment variable is added to the systemd unit file. The recommended approach for Docker socket access is to run a socket proxy (e.g. [tecnativa/docker-socket-proxy](https://github.com/Tecnativa/docker-socket-proxy)) and point `agent_docker_host` at it, rather than adding the agent user to the `docker` group. See [issue #28](https://github.com/ansible-collections/community.beszel/issues/28) for details.
+
 ## Dependencies
 
 This role depends on precompiled binaries published on GitHub at [henrygd/beszel](https://github.com/henrygd/beszel/releases).

--- a/roles/agent/defaults/main.yml
+++ b/roles/agent/defaults/main.yml
@@ -39,3 +39,13 @@ agent_name: ""
 # When true, the Beszel binary agent must be provided on the Ansible Controller
 # and will be copied to the target host instead of being downloaded from GitHub
 agent_airgap: false
+# Groups to add the Beszel binary agent user to
+# WARNING: Adding the user to the 'docker' group grants effective root access
+# and defeats systemd sandboxing. Use agent_docker_host with a socket proxy instead.
+# Example to restore old docker-group behaviour (not recommended):
+#   agent_user_groups:
+#     - docker
+agent_user_groups: []
+# Docker host URL for the Beszel binary agent to use for container statistics
+# Example (socket proxy): agent_docker_host: "tcp://localhost:2375"
+agent_docker_host: ""

--- a/roles/agent/defaults/main.yml
+++ b/roles/agent/defaults/main.yml
@@ -18,6 +18,8 @@ agent_public_key: ""
 agent_install_dir: /usr/local/bin
 # Name of the user to create and run the Beszel binary agent as
 agent_user: beszel
+# UID for the agent user used to run the Beszel binary agent (chosen automatically by the OS if not specified).
+# agent_uid: 1001
 # Custom arguments for the Beszel binary agent
 agent_args: ""
 # Enable the Beszel binary agent systemd service on boot

--- a/roles/agent/defaults/main.yml
+++ b/roles/agent/defaults/main.yml
@@ -28,6 +28,20 @@ agent_service_enabled: true
 agent_service_state: started
 # Extra filesystems to be monitored by the Beszel binary agent
 agent_extra_filesystems: []
+# Interval between S.M.A.R.T checks by the Beszel binary agent
+agent_smart_interval: 1h
+# Disks to be S.M.A.R.T monitored by the Beszel binary agent
+agent_smart_disks: []
+# GPU devices to be monitored by the Beszel binary agent
+# Each GPU should be a dict with 'path' and 'type' keys.
+# Example:
+#   agent_gpus:
+#     - path: /dev/nvidia0
+#       type: nvidia
+#     - path: /dev/dri/card0
+#       type: intel
+# Supported types: nvidia, intel, amd
+agent_gpus: []
 # URL of the Beszel hub for the Beszel binary agent to connect to
 agent_hub_url: ""
 # Universal token used for automatic registration with Beszel hub

--- a/roles/agent/tasks/agent_present.yml
+++ b/roles/agent/tasks/agent_present.yml
@@ -12,9 +12,6 @@
       Required: agent_public_key must always be provided.
       If agent_token is provided, then agent_hub_url must also be provided.
 
-- name: agent_present | Gather package facts
-  ansible.builtin.package_facts:
-
 - name: agent_present | Download and install Beszel binary agent from GitHub
   when: not agent_airgap
   block:
@@ -71,7 +68,7 @@
     shell: /sbin/nologin
     system: true
     create_home: false
-    groups: "{{ 'docker' if ansible_facts.packages['docker-ce'] is defined else omit }}"
+    groups: "{{ agent_user_groups if agent_user_groups | length > 0 else omit }}"
     append: true
     state: present
 

--- a/roles/agent/tasks/agent_present.yml
+++ b/roles/agent/tasks/agent_present.yml
@@ -18,15 +18,15 @@
     - name: agent_present | Determine Beszel binary agent architecture
       ansible.builtin.set_fact:
         agent_beszel_architecture: >-
-          {% if ansible_architecture == 'x86_64' %}
+          {% if ansible_facts['architecture'] == 'x86_64' %}
             amd64
-          {% elif ansible_architecture == 'aarch64' %}
+          {% elif ansible_facts['architecture'] == 'aarch64' %}
             arm64
-          {% elif ansible_architecture == 'arm64' %}
+          {% elif ansible_facts['architecture'] == 'arm64' %}
             arm64
-          {% elif ansible_architecture == 'armv6l' %}
+          {% elif ansible_facts['architecture'] == 'armv6l' %}
             arm
-          {% elif ansible_architecture == 'armv7l' %}
+          {% elif ansible_facts['architecture'] == 'armv7l' %}
             arm
           {% endif %}
 

--- a/roles/agent/tasks/agent_present.yml
+++ b/roles/agent/tasks/agent_present.yml
@@ -12,6 +12,16 @@
       Required: agent_public_key must always be provided.
       If agent_token is provided, then agent_hub_url must also be provided.
 
+- name: agent_present | Assert agent_gpus entries have required keys
+  when: agent_gpus | length > 0
+  ansible.builtin.assert:
+    that:
+      - agent_gpus | rejectattr('path', 'defined') | list | length == 0
+      - agent_gpus | rejectattr('type', 'defined') | list | length == 0
+    fail_msg: >-
+      Each entry in agent_gpus must have both 'path' and 'type' keys.
+      Example: { path: /dev/nvidia0, type: nvidia }
+
 - name: agent_present | Download and install Beszel binary agent from GitHub
   when: not agent_airgap
   block:
@@ -69,6 +79,47 @@
     system: true
     create_home: false
     groups: "{{ agent_user_groups if agent_user_groups | length > 0 else omit }}"
+    state: present
+
+- name: agent_present | Install smartmontools for S.M.A.R.T disk monitoring
+  when: agent_smart_disks | length > 0
+  ansible.builtin.package:
+    name: smartmontools
+    state: present
+
+- name: agent_present | Add beszel user to disk group for S.M.A.R.T disk access
+  when: agent_smart_disks | length > 0
+  ansible.builtin.user:
+    name: "{{ agent_user }}"
+    groups: disk
+    append: true
+
+- name: agent_present | Check if nvidia-smi is already installed
+  when:
+    - agent_gpus | length > 0
+    - agent_gpus | selectattr('type', 'equalto', 'nvidia') | list | length > 0
+  ansible.builtin.command: which nvidia-smi
+  register: agent_nvidia_smi_check
+  changed_when: false
+  failed_when: false
+
+- name: agent_present | Install NVIDIA GPU monitoring tools
+  when:
+    - agent_gpus | length > 0
+    - agent_gpus | selectattr('type', 'equalto', 'nvidia') | list | length > 0
+    - agent_nvidia_smi_check.rc != 0
+  ansible.builtin.package:
+    name:
+      - nvidia-smi
+      - nvtop
+    state: present
+
+- name: agent_present | Install Intel GPU monitoring tools
+  when:
+    - agent_gpus | length > 0
+    - agent_gpus | selectattr('type', 'equalto', 'intel') | list | length > 0
+  ansible.builtin.package:
+    name: intel-gpu-tools
     state: present
 
 - name: agent_present | Install Beszel binary agent systemd service

--- a/roles/agent/tasks/agent_present.yml
+++ b/roles/agent/tasks/agent_present.yml
@@ -69,7 +69,6 @@
     system: true
     create_home: false
     groups: "{{ agent_user_groups if agent_user_groups | length > 0 else omit }}"
-    append: true
     state: present
 
 - name: agent_present | Install Beszel binary agent systemd service

--- a/roles/agent/templates/beszel-agent.service.j2
+++ b/roles/agent/templates/beszel-agent.service.j2
@@ -20,6 +20,9 @@ Environment="SYSTEM_NAME={{ agent_name }}"
 {% if agent_extra_filesystems %}
 Environment="EXTRA_FILESYSTEMS={{ agent_extra_filesystems | join(',') }}"
 {% endif %}
+{% if agent_docker_host %}
+Environment="DOCKER_HOST={{ agent_docker_host }}"
+{% endif %}
 Restart=on-failure
 RestartSec=5
 StateDirectory=beszel-agent

--- a/roles/agent/templates/beszel-agent.service.j2
+++ b/roles/agent/templates/beszel-agent.service.j2
@@ -8,6 +8,7 @@ User={{ agent_user }}
 ExecStart={{ agent_install_dir }}/beszel-agent {{ agent_args | trim }}
 Environment="PORT={{ agent_port }}"
 Environment="KEY={{ agent_public_key }}"
+Environment="SMART_INTERVAL={{ agent_smart_interval }}"
 {% if agent_hub_url %}
 Environment="HUB_URL={{ agent_hub_url }}"
 {% endif %}
@@ -26,7 +27,26 @@ Environment="DOCKER_HOST={{ agent_docker_host }}"
 Restart=on-failure
 RestartSec=5
 StateDirectory=beszel-agent
-
+{# Pre-compute device type flags to avoid repeated filter expressions #}
+{% set _has_smart = agent_smart_disks | length > 0 %}
+{% set _has_nvidia = agent_gpus | selectattr('type', 'equalto', 'nvidia') | list | length > 0 %}
+{% set _has_intel = agent_gpus | selectattr('type', 'equalto', 'intel') | list | length > 0 %}
+{% set _caps = (['CAP_SYS_RAWIO', 'CAP_SYS_ADMIN'] if _has_smart else []) + (['CAP_PERFMON'] if _has_intel else []) %}
+{% if _caps %}
+AmbientCapabilities={{ _caps | join(' ') }}
+{% endif %}
+{% if _has_smart %}
+CapabilityBoundingSet={{ _caps | join(' ') }}
+{% endif %}
+{% if _has_nvidia %}
+DeviceAllow=/dev/nvidiactl rw
+{% endif %}
+{% for gpu in agent_gpus %}
+DeviceAllow={{ gpu.path }} rw
+{% endfor %}
+{% for disk in agent_smart_disks %}
+DeviceAllow={{ disk }} r
+{% endfor %}
 # Security/sandboxing settings
 KeyringMode=private
 LockPersonality=yes

--- a/roles/hub/README.md
+++ b/roles/hub/README.md
@@ -41,6 +41,18 @@ hub_user: beszel
 Name of the user to create and run the Beszel hub as.
 
 ```yaml
+# hub_uid: 1001
+```
+
+UID for the hub user used to run the Beszel hub. Chosen automatically by the OS if not specified.
+
+```yaml
+hub_user_groups: []
+```
+
+Groups to add the Beszel hub user to.
+
+```yaml
 hub_args: ""
 ```
 

--- a/roles/hub/README.md
+++ b/roles/hub/README.md
@@ -17,6 +17,12 @@ hub_version: latest
 Version of the Beszel hub to install. Can be a specific version from GitHub (e.g., `v0.9.1`).
 
 ```yaml
+hub_bind_address: 0.0.0.0
+```
+
+Bind address for the Beszel hub to listen on.
+
+```yaml
 hub_port: 8090
 ```
 

--- a/roles/hub/defaults/main.yml
+++ b/roles/hub/defaults/main.yml
@@ -9,6 +9,8 @@ hub_state: present
 # Version of the Beszel hub to install
 # Can be a specific version from GitHub (e.g., v0.9.1)
 hub_version: latest
+# Bind address for the Beszel hub to listen on
+hub_bind_address: 0.0.0.0
 # Port for the Beszel hub to listen on
 hub_port: 8090
 # Directory to install the Beszel hub into

--- a/roles/hub/defaults/main.yml
+++ b/roles/hub/defaults/main.yml
@@ -17,6 +17,10 @@ hub_install_dir: /usr/local/bin
 hub_data_dir: /var/lib/beszel
 # Name of the user to create and run the Beszel hub as
 hub_user: beszel
+# UID for the hub user used to run the Beszel hub (chosen automatically by the OS if not specified).
+# hub_uid: 1001
+# Groups to add the Beszel hub user to
+hub_user_groups: []
 # Custom arguments for the Beszel hub
 hub_args: ""
 # Enable the Beszel hub systemd service on boot

--- a/roles/hub/tasks/hub_present.yml
+++ b/roles/hub/tasks/hub_present.yml
@@ -1,8 +1,5 @@
 ---
 # present tasks file for hub
-- name: hub_present | Gather package facts
-  ansible.builtin.package_facts:
-
 - name: hub_present | Determine Beszel hub architecture
   ansible.builtin.set_fact:
     hub_beszel_architecture: >-
@@ -40,10 +37,11 @@
 - name: hub_present | Create user for the Beszel hub
   ansible.builtin.user:
     name: "{{ hub_user }}"
+    uid: "{{ hub_uid | default(omit) }}"
     shell: /sbin/nologin
     system: true
     create_home: false
-    groups: "{{ 'docker' if ansible_facts.packages['docker-ce'] is defined else omit }}"
+    groups: "{{ hub_user_groups if hub_user_groups | length > 0 else omit }}"
     state: present
 
 - name: hub_present | Create data directory for the Beszel hub

--- a/roles/hub/tasks/hub_present.yml
+++ b/roles/hub/tasks/hub_present.yml
@@ -44,7 +44,6 @@
     system: true
     create_home: false
     groups: "{{ 'docker' if ansible_facts.packages['docker-ce'] is defined else omit }}"
-    append: true
     state: present
 
 - name: hub_present | Create data directory for the Beszel hub

--- a/roles/hub/tasks/hub_present.yml
+++ b/roles/hub/tasks/hub_present.yml
@@ -6,13 +6,13 @@
 - name: hub_present | Determine Beszel hub architecture
   ansible.builtin.set_fact:
     hub_beszel_architecture: >-
-      {% if ansible_architecture == 'x86_64' %}
+      {% if ansible_facts['architecture'] == 'x86_64' %}
         amd64
-      {% elif ansible_architecture == 'aarch64' %}
+      {% elif ansible_facts['architecture'] == 'aarch64' %}
         arm64
-      {% elif ansible_architecture == 'armv6l' %}
+      {% elif ansible_facts['architecture'] == 'armv6l' %}
         arm
-      {% elif ansible_architecture == 'armv7l' %}
+      {% elif ansible_facts['architecture'] == 'armv7l' %}
         arm
       {% endif %}
 

--- a/roles/hub/templates/beszel-hub.service.j2
+++ b/roles/hub/templates/beszel-hub.service.j2
@@ -8,7 +8,7 @@ Restart=always
 RestartSec=3
 User={{ hub_user }}
 WorkingDirectory={{ hub_data_dir }}
-ExecStart={{ hub_install_dir }}/beszel serve --http 0.0.0.0:{{ hub_port }} {{ hub_args }}
+ExecStart={{ hub_install_dir }}/beszel serve --http {{ hub_bind_address }}:{{ hub_port }} {{ hub_args }}
 
 [Install]
 WantedBy=multi-user.target

--- a/uv.lock
+++ b/uv.lock
@@ -270,7 +270,7 @@ wheels = [
 
 [[package]]
 name = "community-beszel"
-version = "0.8.0"
+version = "1.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "ansible-core" },

--- a/uv.lock
+++ b/uv.lock
@@ -103,8 +103,8 @@ wheels = [
 
 [[package]]
 name = "antsibull-nox"
-version = "1.3.2.post0"
-source = { git = "https://github.com/ansible-community/antsibull-nox?rev=a4f9b2f#a4f9b2f1aef9e3f96d111dbe98d291cdc5009c74" }
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "antsibull-fileutils" },
     { name = "nox" },
@@ -112,6 +112,10 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "semantic-version" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/da/45e9e5f0399f33e33cdacd7bf6bd42e6f9023e62c9c31dcd82b40972a877/antsibull_nox-1.5.0.tar.gz", hash = "sha256:0257e739236988ca04d439600b438125e441f4617459a91f19ecc3c14b379bc0", size = 191125, upload-time = "2026-01-05T19:36:30.97Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/63/49bb0a019c273a3e33e0d2c9c8d27c75631ac1ba1ab669f179c6be9ffc5c/antsibull_nox-1.5.0-py3-none-any.whl", hash = "sha256:4f7b07e9aa5d9f95628655e8726dc235b3fe80a9e25fdd1ce8419e50846a54b8", size = 144286, upload-time = "2026-01-05T19:36:29.318Z" },
 ]
 
 [[package]]
@@ -266,7 +270,7 @@ wheels = [
 
 [[package]]
 name = "community-beszel"
-version = "0.7.0"
+version = "0.8.0"
 source = { virtual = "." }
 dependencies = [
     { name = "ansible-core" },
@@ -298,15 +302,15 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "antsibull-changelog", extras = ["toml"], specifier = ">=0.34.0" },
-    { name = "antsibull-nox", git = "https://github.com/ansible-community/antsibull-nox?rev=a4f9b2f" },
+    { name = "antsibull-nox", specifier = ">=1.5.0" },
     { name = "codespell", specifier = ">=2.4.1" },
-    { name = "jmespath", specifier = "==1.0.1" },
+    { name = "jmespath", specifier = ">=1.0.1" },
     { name = "molecule", specifier = ">=25.12.0" },
     { name = "molecule-plugins", extras = ["docker"], specifier = ">=25.8.12" },
     { name = "prek", specifier = ">=0.2.20" },
 ]
 test = [
-    { name = "jmespath", specifier = "==1.0.1" },
+    { name = "jmespath", specifier = ">=1.0.1" },
     { name = "molecule", specifier = ">=25.12.0" },
     { name = "molecule-plugins", extras = ["docker"], specifier = ">=25.8.12" },
 ]


### PR DESCRIPTION
## Summary

This PR prepares the `community.beszel` collection for the **1.0.0** release. It includes new features for the `agent` and `hub` roles, bug fixes, refactoring for consistency, CI hardening, and developer tooling additions.

---

## Changes

### Features

- **`agent` role — configurable Docker group and socket host**: Replaces the previous behaviour of automatically adding the agent user to the `docker` group when `docker-ce` was detected. Introduces two new variables:
  - `agent_user_groups` — explicit list of groups to add the agent user to (default: `[]`)
  - `agent_docker_host` — injects a `DOCKER_HOST` environment variable into the systemd unit, enabling socket-proxy based Docker access without granting effective root via the `docker` group
  - Removes the `package_facts` gather task that was only needed for docker-ce detection

Fixes #28.

- **`agent` role — GPU and S.M.A.R.T disk monitoring** (merged from #34): Adds support for GPU and S.M.A.R.T disk monitoring via two new variables:
  - `agent_gpus` — list of GPU devices to monitor, each entry specifying a `path` and `type` (`nvidia`, `intel`, or `amd`); installs GPU-specific packages and grants the required `DeviceAllow` and `AmbientCapabilities` (`CAP_PERFMON`) in the systemd unit
  - `agent_smart_disks` — list of block devices to monitor for S.M.A.R.T data; installs `smartmontools`, adds the agent user to the `disk` group, and grants `CAP_SYS_RAWIO`/`CAP_SYS_ADMIN` capabilities and `DeviceAllow` entries in the systemd unit
  - `agent_smart_interval` — optional interval override for S.M.A.R.T polling

- **`hub` role — configurable UID and user groups**: Brings the `hub` role to parity with the `agent` role by replacing the hard-coded docker-ce group detection with explicit variables:
  - `hub_uid` — optional UID for the hub service user (chosen by the OS if not set)
  - `hub_user_groups` — explicit list of groups to add the hub user to (default: `[]`)
  - Removes the `package_facts` gather task that was only needed for docker-ce detection

- **`hub` role — configurable bind address** (merged from #37): Adds `hub_bind_address` to allow customising the address the hub service listens on. Useful for restricting access to localhost when the hub is deployed behind a reverse proxy.

- **Claude Code commit skill**: Adds `.claude/skills/commit/SKILL.md` — an AI agent skill for creating conventional commits with FQCN scopes for Ansible collection content, with automatic splitting of changed files into separate, focused commits per collection component.

- **Claude Code changelogs skill**: Adds `.claude/skills/changelogs/SKILL.md` — an AI agent skill for inspecting branch commits, categorising them using antsibull-changelog fragment categories, writing a changelog fragment YAML, and running the changelog generation command.

### Bug Fixes

- **Remove `append: true` from user creation tasks**: Removes the `append: true` flag from `ansible.builtin.user` tasks in both the `agent` and `hub` roles. This prevents unintended group memberships from being preserved when the managed user already exists. Fixes #36.

### Refactoring

- **Use `ansible_facts['architecture']`**: Replaces bare `ansible_architecture` variable references with the explicit `ansible_facts['architecture']` dict lookup in the `agent` role tasks, `hub` role tasks, and the `agent_airgap` molecule scenario, for consistency with Ansible best practices. Fixes #32.

- **Commit skill — breaking-change prefix**: Updates the commit skill to use the correct breaking-change commit type prefix.

### Chores / CI

- **Pin GitHub Actions to commit hashes**: Pins all actions in `ansible-molecule.yml` and `antsibull-nox.yml` to specific commit SHAs for supply-chain security.
- **Bump collection version** to `1.0.0` in `galaxy.yml` and add `build_ignore` entries.
- **Update `pyproject.toml`**: Bumps `antsibull-nox` to `>=1.5.0` and `jmespath` to `>=1.0.1`, removes unused upper bounds.
- **Update `uv.lock`** to reflect dependency changes.
- **Add `.DS_Store` to `.gitignore`**.

### Documentation

- **`agent` README**: Documents the new `agent_user_groups`, `agent_docker_host`, `agent_gpus`, `agent_smart_disks`, and `agent_smart_interval` variables, including security warnings about the `docker` group and notes on NVMe devices for S.M.A.R.T monitoring.
- **`hub` README**: Documents the new `hub_uid` and `hub_user_groups` variables.
- **Fix missing `agent_uid` default**: Adds the `agent_uid` variable (commented out) to `roles/agent/defaults/main.yml`.
- **Change "Contributors" heading** to "Original Contributors" in the agent README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)