### PR TITLE
fix: pin pocketbase SDK to 0.15.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Ansible Core 2.17, 2.18, 2.19 and 2.20.
 To use the modules in this collection you will need:
 
 - Python >= 3.9
-- Pocketbase >= 0.15.0
+- Pocketbase == 0.15.0
 
 ## Using this collection
 

--- a/changelogs/fragments/restrict-pocketbase-sdk-0.15.0.yml
+++ b/changelogs/fragments/restrict-pocketbase-sdk-0.15.0.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Pin the controller-side ``pocketbase`` dependency to ``0.15.0`` to address issue `#42 <https://github.com/ansible-collections/community.beszel/issues/42>`__.

--- a/meta/ee-requirements.txt
+++ b/meta/ee-requirements.txt
@@ -9,4 +9,4 @@
 # See https://ansible.readthedocs.io/projects/builder/en/latest/collection_metadata/#how-to-verify-collection-level-metadata
 # to learn how to test your configuration.
 # Do not delete this file even if the collection has no dependencies!
-pocketbase<=0.15.0
+pocketbase==0.15.0

--- a/meta/ee-requirements.txt
+++ b/meta/ee-requirements.txt
@@ -9,4 +9,4 @@
 # See https://ansible.readthedocs.io/projects/builder/en/latest/collection_metadata/#how-to-verify-collection-level-metadata
 # to learn how to test your configuration.
 # Do not delete this file even if the collection has no dependencies!
-pocketbase>=0.15.0
+pocketbase<=0.15.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.13, <3.14"
 dependencies = [
     "ansible-core==2.20.0",
-    "pocketbase>=0.15.0",
+    "pocketbase<=0.15.0",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.13, <3.14"
 dependencies = [
     "ansible-core==2.20.0",
-    "pocketbase<=0.15.0",
+    "pocketbase==0.15.0",
 ]
 
 [dependency-groups]

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -1,2 +1,2 @@
 # Integration tests dependencies
-pocketbase
+pocketbase==0.15.0

--- a/uv.lock
+++ b/uv.lock
@@ -296,7 +296,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "ansible-core", specifier = "==2.20.0" },
-    { name = "pocketbase", specifier = ">=0.15.0" },
+    { name = "pocketbase", specifier = "<=0.15.0" },
 ]
 
 [package.metadata.requires-dev]

--- a/uv.lock
+++ b/uv.lock
@@ -296,7 +296,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "ansible-core", specifier = "==2.20.0" },
-    { name = "pocketbase", specifier = "<=0.15.0" },
+    { name = "pocketbase", specifier = "==0.15.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary
- pin the controller-side pocketbase dependency to 0.15.0
- apply the same pin in execution-environment and integration test requirements
- update the README and add a changelog fragment for issue #42

Closes #42

## Testing
- uv run prek run --all-files
- uv run nox -e ansible-test-units